### PR TITLE
fix #83 - Last items of the left menu are hidden (behind the footer)

### DIFF
--- a/tracim/tracim/public/assets/css/dashboard.css
+++ b/tracim/tracim/public/assets/css/dashboard.css
@@ -290,6 +290,11 @@ div.t-page-metadata-row, div.t-metadata-row {
 #sidebar-left .btn.btn-link,
 #sidebar-left .list-unstyled a {
     color: #DDD;
+    margin-bottom: 20px; /* avoid left menu to be overwritten by footer */
+}
+
+#sidebar-left-menu {
+    margin-bottom: 20px; /* add a margin between menu bottom and footer top */
 }
 
 h1.page-header {


### PR DESCRIPTION
add a bottom margin to left menu, so that last items in the menu are never hidden by the footer