### PR TITLE
Closes #107: folder sub_items must be filtered (temporary, archived, …) to

### DIFF
--- a/tracim/tracim/controllers/content.py
+++ b/tracim/tracim/controllers/content.py
@@ -712,11 +712,17 @@ class UserWorkspaceFolderRestController(TIMRestControllerWithBreadcrumb):
 
         fake_api = Context(CTX.FOLDER).toDict(fake_api_content)
 
-        fake_api.sub_items = Context(CTX.FOLDER_CONTENT_LIST).toDict(
-            folder.get_valid_children([ContentType.Folder,
-                                       ContentType.File,
-                                       ContentType.Page,
-                                       ContentType.Thread]))
+        sub_items = content_api.get_children(
+            parent_id=folder.content_id,
+            content_types=[
+                ContentType.Folder,
+                ContentType.File,
+                ContentType.Page,
+                ContentType.Thread,
+            ],
+
+        )
+        fake_api.sub_items = Context(CTX.FOLDER_CONTENT_LIST).toDict(sub_items)
 
         fake_api.content_types = Context(CTX.DEFAULT).toDict(
             content_api.get_all_types())

--- a/tracim/tracim/lib/content.py
+++ b/tracim/tracim/lib/content.py
@@ -464,6 +464,24 @@ class ContentApi(object):
 
         return resultset.all()
 
+    def get_children(self, parent_id: int, content_types: list, workspace: Workspace=None) -> [Content]:
+        """
+        Return parent_id childs of given content_types
+        :param parent_id: parent id
+        :param content_types: list of types
+        :param workspace: workspace filter
+        :return: list of content
+        """
+        resultset = self._base_query(workspace)
+        resultset = resultset.filter(Content.type.in_(content_types))
+
+        if parent_id:
+            resultset = resultset.filter(Content.parent_id==parent_id)
+        if parent_id is False:
+            resultset = resultset.filter(Content.parent_id == None)
+
+        return resultset.all()
+
     # TODO find an other name to filter on is_deleted / is_archived
     def get_all_with_filter(self, parent_id: int=None, content_type: str=ContentType.Any, workspace: Workspace=None) -> [Content]:
         assert parent_id is None or isinstance(parent_id, int) # DYN_REMOVE


### PR DESCRIPTION
Anciennement, l'usage de ``folder.get_valid_children`` faisait qu'on ne réutilisait pas la même "configuration" qu'avec l'instance de ``ContentApi``.

J'ai également du rajouter ``ContentApi.get_children``. Je voulais utiliser ``ContentApi.get_all`` mais elle ne permet de préciser qu'un seul ``ContentType``. Or le code actuel précise cette liste:

```
            [
                ContentType.Folder,
                ContentType.File,
                ContentType.Page,
                ContentType.Thread,
            ]
```