### PR TITLE
change stopping tracim strategy

### DIFF
--- a/tracim/tracim/config/app_cfg.py
+++ b/tracim/tracim/config/app_cfg.py
@@ -22,6 +22,7 @@ from tg.configuration.milestones import environment_loaded
 
 from tgext.pluggable import plug
 from tgext.pluggable import replace_template
+from tracim.lib.system import InterruptManager
 
 from tracim.lib.utils import lazy_ugettext as l_
 
@@ -109,6 +110,7 @@ def start_daemons(manager: DaemonsManager):
         manager.run('mail_sender', MailSenderDaemon)
 
 environment_loaded.register(lambda: start_daemons(daemons))
+interrupt_manager = InterruptManager(daemons_manager=daemons)
 
 # Note: here are fake translatable strings that allow to translate messages for reset password email content
 duplicated_email_subject = l_('Password reset request')

--- a/tracim/tracim/config/app_cfg.py
+++ b/tracim/tracim/config/app_cfg.py
@@ -14,6 +14,7 @@ convert them into boolean, for example, you should use the
 """
 import imp
 import importlib
+import os
 from urllib.parse import urlparse
 
 import tg
@@ -110,7 +111,7 @@ def start_daemons(manager: DaemonsManager):
         manager.run('mail_sender', MailSenderDaemon)
 
 environment_loaded.register(lambda: start_daemons(daemons))
-interrupt_manager = InterruptManager(daemons_manager=daemons)
+interrupt_manager = InterruptManager(os.getpid(), daemons_manager=daemons)
 
 # Note: here are fake translatable strings that allow to translate messages for reset password email content
 duplicated_email_subject = l_('Password reset request')

--- a/tracim/tracim/lib/daemons.py
+++ b/tracim/tracim/lib/daemons.py
@@ -18,7 +18,7 @@ from rq.worker import StopRequested
 from tracim.lib.base import logger
 from tracim.lib.exceptions import AlreadyRunningDaemon
 
-from tracim.tracim.lib.utils import get_rq_queue
+from tracim.lib.utils import get_rq_queue
 
 
 class DaemonsManager(object):
@@ -163,7 +163,7 @@ class MailSenderDaemon(Daemon):
         pass
 
     def stop(self) -> None:
-        # When _stop_requested at False, tracim.tracim.lib.daemons.RQWorker
+        # When _stop_requested at False, tracim.lib.daemons.RQWorker
         # will raise StopRequested exception in worker thread after receive a
         # job.
         self.worker._stop_requested = True

--- a/tracim/tracim/lib/email.py
+++ b/tracim/tracim/lib/email.py
@@ -15,24 +15,24 @@ from tracim.lib.utils import get_rq_queue
 
 
 def send_email_through(
-        send_callable: typing.Callable[[Message], None],
+        sendmail_callable: typing.Callable[[Message], None],
         message: Message,
 ) -> None:
     """
     Send mail encapsulation to send it in async or sync mode.
     TODO BS 20170126: A global mail/sender management should be a good
                       thing. Actually, this method is an fast solution.
-    :param send_callable: A callable who get message on first parameter
+    :param sendmail_callable: A callable who get message on first parameter
     :param message: The message who have to be sent
     """
     from tracim.config.app_cfg import CFG
     cfg = CFG.get_instance()
 
     if cfg.EMAIL_PROCESSING_MODE == CFG.CST.SYNC:
-        send_callable(message)
+        sendmail_callable(message)
     elif cfg.EMAIL_PROCESSING_MODE == CFG.CST.ASYNC:
         queue = get_rq_queue('mail_sender')
-        queue.enqueue(send_callable, message)
+        queue.enqueue(sendmail_callable, message)
     else:
         raise NotImplementedError(
             'Mail sender processing mode {} is not implemented'.format(

--- a/tracim/tracim/lib/email.py
+++ b/tracim/tracim/lib/email.py
@@ -6,12 +6,12 @@ from email.mime.text import MIMEText
 
 import typing
 from mako.template import Template
-from redis import Redis
-from rq import Queue
 from tg.i18n import ugettext as _
 
 from tracim.lib.base import logger
 from tracim.model import User
+
+from tracim.tracim.lib.utils import get_rq_queue
 
 
 def send_email_through(
@@ -31,11 +31,7 @@ def send_email_through(
     if cfg.EMAIL_PROCESSING_MODE == CFG.CST.SYNC:
         send_callable(message)
     elif cfg.EMAIL_PROCESSING_MODE == CFG.CST.ASYNC:
-        queue = Queue('mail_sender', connection=Redis(
-            host=cfg.EMAIL_SENDER_REDIS_HOST,
-            port=cfg.EMAIL_SENDER_REDIS_PORT,
-            db=cfg.EMAIL_SENDER_REDIS_DB,
-        ))
+        queue = get_rq_queue('mail_sender')
         queue.enqueue(send_callable, message)
     else:
         raise NotImplementedError(

--- a/tracim/tracim/lib/email.py
+++ b/tracim/tracim/lib/email.py
@@ -11,7 +11,7 @@ from tg.i18n import ugettext as _
 from tracim.lib.base import logger
 from tracim.model import User
 
-from tracim.tracim.lib.utils import get_rq_queue
+from tracim.lib.utils import get_rq_queue
 
 
 def send_email_through(

--- a/tracim/tracim/lib/system.py
+++ b/tracim/tracim/lib/system.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+import os
+import signal
+
+from tracim.lib.daemons import DaemonsManager
+
+
+class InterruptManager(object):
+    def __init__(self, daemons_manager: DaemonsManager):
+        self.daemons_manager = daemons_manager
+        self.process_pid = os.getpid()
+        self._install_sgnal_handlers()
+
+    def _install_sgnal_handlers(self) -> None:
+        """
+        Install signal handler to intercept SIGINT and SIGTERM signals
+        """
+        signal.signal(signal.SIGTERM, self.stop)
+        signal.signal(signal.SIGINT, self.stop)
+
+    def _remove_signal_handlers(self) -> None:
+        """
+        Remove installed signals to permit stop of main thread.
+        """
+        signal.signal(signal.SIGTERM, signal.SIG_DFL)
+        signal.signal(signal.SIGINT, signal.SIG_DFL)
+
+    def stop(self, signum, frame) -> None:
+        """
+        Run stopping process needed when tracim have to stop.
+        :param signum: signal interruption value
+        :param frame: frame of signal origin
+        """
+        self._remove_signal_handlers()
+        self.daemons_manager.stop_all()
+        # Web server is managed by end of stack like uwsgi, apache2.
+        # So to ask it's termination, we have to use standard kills signals
+        os.kill(self.process_pid, signum)

--- a/tracim/tracim/lib/system.py
+++ b/tracim/tracim/lib/system.py
@@ -6,6 +6,16 @@ from tracim.lib.daemons import DaemonsManager
 
 
 class InterruptManager(object):
+    """
+    Manager interruption of tracim components.
+
+    Stop all tracim daemons, then:
+
+    With a specific production server like uWSGI, we should use master
+    FIFO system to exit properly the program:
+    https://github.com/unbit/uwsgi/issues/849. But to be generic, we resend the
+    signal after intercept it.
+    """
     def __init__(
             self,
             tracim_process_pid: int,
@@ -41,6 +51,4 @@ class InterruptManager(object):
         """
         self._remove_signal_handlers()
         self.daemons_manager.stop_all()
-        # Web server is managed by end of stack like uwsgi, apache2.
-        # So to ask it's termination, we have to use standard kills signals
         os.kill(self.tracim_process_pid, signum)

--- a/tracim/tracim/lib/system.py
+++ b/tracim/tracim/lib/system.py
@@ -6,9 +6,17 @@ from tracim.lib.daemons import DaemonsManager
 
 
 class InterruptManager(object):
-    def __init__(self, daemons_manager: DaemonsManager):
+    def __init__(
+            self,
+            tracim_process_pid: int,
+            daemons_manager: DaemonsManager,
+    ) -> None:
+        """
+        :param tracim_process_pid: pid of tracim.
+        :param daemons_manager: Tracim daemons manager
+        """
         self.daemons_manager = daemons_manager
-        self.process_pid = os.getpid()
+        self.tracim_process_pid = tracim_process_pid
         self._install_sgnal_handlers()
 
     def _install_sgnal_handlers(self) -> None:
@@ -35,4 +43,4 @@ class InterruptManager(object):
         self.daemons_manager.stop_all()
         # Web server is managed by end of stack like uwsgi, apache2.
         # So to ask it's termination, we have to use standard kills signals
-        os.kill(self.process_pid, signum)
+        os.kill(self.tracim_process_pid, signum)


### PR DESCRIPTION
Avec ces changements Tracim se ferme enfin correctement:
* Le worker RQ se termine également correctement: J'ai procédé à une astuce : on passe l'attribut du worker, dans le daemon,`_stop_requested` à vrai depuis le main thread. Et un surcharge dans le worker vérifie cet attribut entre chaque "traitement" de job. On fait par la suite faire au worker un job "bidon" (d'ailleurs il y a un job bidon à disposition dans le code de rq, à se demander si ça sert pas à un truc similaire), notre surcharge lève par la suite un StopRequested qui applique la procédure standard d'arrêt du worker.
* Une fois les démons arrétés on fait un kill sur le processus de tracim. Après avoir essayé de trouver un moyen de stopper "softwarement" le process du serveur WSGI je me suis randu compte que ce n'était peut-être pas vraiment possible: le serevur étant créé/géré à un niveau plus élevé, par uwsgi ou apache2 par exemple. D'ailleurs, en fouillant dans les commande gearbox j'ai vu qu'il faisait des kill lui aussi.
Tu me dira ce que tu pense de cette stratégie et si ça mérite d'être intégré dans la beta 1.0 : )