### PR TITLE
Better escaping for mail header with formataddr method

### DIFF
--- a/tracim/tracim/lib/email.py
+++ b/tracim/tracim/lib/email.py
@@ -159,9 +159,9 @@ class EmailManager(object):
         message['Subject'] = subject
         message['From'] = formataddr((
             self._global_config.EMAIL_NOTIFICATION_FROM_DEFAULT_LABEL,
-            self._global_config.EMAIL_NOTIFICATION_FROM_EMAIL)
-        )
-        message['To'] = formataddr(('',user.email))
+            self._global_config.EMAIL_NOTIFICATION_FROM_EMAIL,
+        ))
+        message['To'] = formataddr(('', user.email))
 
         text_template_file_path = self._global_config.EMAIL_NOTIFICATION_CREATED_ACCOUNT_TEMPLATE_TEXT  # nopep8
         html_template_file_path = self._global_config.EMAIL_NOTIFICATION_CREATED_ACCOUNT_TEMPLATE_HTML  # nopep8

--- a/tracim/tracim/lib/email.py
+++ b/tracim/tracim/lib/email.py
@@ -161,7 +161,7 @@ class EmailManager(object):
             self._global_config.EMAIL_NOTIFICATION_FROM_DEFAULT_LABEL,
             self._global_config.EMAIL_NOTIFICATION_FROM_EMAIL,
         ))
-        message['To'] = formataddr(('', user.email))
+        message['To'] = formataddr((user.get_display_name(), user.email))
 
         text_template_file_path = self._global_config.EMAIL_NOTIFICATION_CREATED_ACCOUNT_TEMPLATE_TEXT  # nopep8
         html_template_file_path = self._global_config.EMAIL_NOTIFICATION_CREATED_ACCOUNT_TEMPLATE_HTML  # nopep8

--- a/tracim/tracim/lib/email.py
+++ b/tracim/tracim/lib/email.py
@@ -4,6 +4,7 @@ import typing
 from email.message import Message
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+from email.utils import formataddr
 
 from mako.template import Template
 from tg.i18n import ugettext as _
@@ -156,11 +157,11 @@ class EmailManager(object):
             )
         message = MIMEMultipart('alternative')
         message['Subject'] = subject
-        message['From'] = '{0} <{1}>'.format(
+        message['From'] = formataddr((
             self._global_config.EMAIL_NOTIFICATION_FROM_DEFAULT_LABEL,
-            self._global_config.EMAIL_NOTIFICATION_FROM_EMAIL,
+            self._global_config.EMAIL_NOTIFICATION_FROM_EMAIL)
         )
-        message['To'] = user.email
+        message['To'] = formataddr(('',user.email))
 
         text_template_file_path = self._global_config.EMAIL_NOTIFICATION_CREATED_ACCOUNT_TEMPLATE_TEXT  # nopep8
         html_template_file_path = self._global_config.EMAIL_NOTIFICATION_CREATED_ACCOUNT_TEMPLATE_HTML  # nopep8

--- a/tracim/tracim/lib/notifications.py
+++ b/tracim/tracim/lib/notifications.py
@@ -208,7 +208,7 @@ class EmailNotifier(object):
         else:
             email_address = email_template.replace('{user_id}', '0')
 
-        return formataddr((mail_sender_name,email_address))
+        return formataddr((mail_sender_name, email_address))
 
     @staticmethod
     def log_notification(
@@ -267,7 +267,7 @@ class EmailNotifier(object):
 
         for role in notifiable_roles:
             logger.info(self, 'Sending email to {}'.format(role.user.email))
-            to_addr = formataddr((role.user.display_name,role.user.email))
+            to_addr = formataddr((role.user.display_name, role.user.email))
 
             #
             #  INFO - D.A. - 2014-11-06

--- a/tracim/tracim/lib/notifications.py
+++ b/tracim/tracim/lib/notifications.py
@@ -5,6 +5,7 @@ import typing
 from email.header import Header
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
+from email.utils import formataddr
 
 from lxml.html.diff import htmldiff
 
@@ -207,10 +208,7 @@ class EmailNotifier(object):
         else:
             email_address = email_template.replace('{user_id}', '0')
 
-        return '{label} <{email_address}>'.format(
-            label = Header(mail_sender_name).encode(),
-            email_address = email_address
-        )
+        return formataddr((mail_sender_name,email_address))
 
     @staticmethod
     def log_notification(
@@ -269,7 +267,7 @@ class EmailNotifier(object):
 
         for role in notifiable_roles:
             logger.info(self, 'Sending email to {}'.format(role.user.email))
-            to_addr = '{name} <{email}>'.format(name=role.user.display_name, email=role.user.email)
+            to_addr = formataddr((role.user.display_name,role.user.email))
 
             #
             #  INFO - D.A. - 2014-11-06


### PR DESCRIPTION
Use _formataddr_ from standard lib instead of homemade format for _To_ and _From_ Header in both notification mail and new user mail. Allow to use utf8 character and special character (like @) in "label" part of these header. 
double-quote (**"**) character is also escaped when needed.
Closes #490