### PR TITLE
Imapclient instead of imaplib as imap lib

### DIFF
--- a/install/requirements.txt
+++ b/install/requirements.txt
@@ -68,3 +68,4 @@ click==6.7
 markdown==2.6.9
 email_reply_parser==0.5.9
 filelock==2.0.13
+imapclient==1.1.0

--- a/tracim/development.ini.base
+++ b/tracim/development.ini.base
@@ -222,6 +222,9 @@ email.reply.imap.user = your_imap_user
 email.reply.imap.password = your_imap_password
 email.reply.imap.folder = INBOX
 email.reply.imap.use_ssl = true
+email.reply.imap.use_idle = true
+# Re-new connection each 10 minutes
+email.reply.connection.max_lifetime = 600
 # Token for communication between mail fetcher and tracim controller
 email.reply.token = mysecuretoken
 # Delay in seconds between each check

--- a/tracim/tracim/config/app_cfg.py
+++ b/tracim/tracim/config/app_cfg.py
@@ -384,6 +384,14 @@ class CFG(object):
         self.EMAIL_REPLY_IMAP_USE_SSL = asbool(tg.config.get(
             'email.reply.imap.use_ssl',
         ))
+        self.EMAIL_REPLY_IMAP_USE_IDLE = asbool(tg.config.get(
+            'email.reply.imap.use_idle',
+            True,
+        ))
+        self.EMAIL_REPLY_CONNECTION_MAX_LIFETIME = int(tg.config.get(
+            'email.reply.connection.max_lifetime',
+            600, # 10 minutes
+        ))
         self.EMAIL_REPLY_USE_HTML_PARSING = asbool(tg.config.get(
             'email.reply.use_html_parsing',
             True,

--- a/tracim/tracim/lib/daemons.py
+++ b/tracim/tracim/lib/daemons.py
@@ -173,7 +173,7 @@ class MailFetcherDaemon(Daemon):
             password=cfg.EMAIL_REPLY_IMAP_PASSWORD,
             use_ssl=cfg.EMAIL_REPLY_IMAP_USE_SSL,
             folder=cfg.EMAIL_REPLY_IMAP_FOLDER,
-            delay=cfg.EMAIL_REPLY_CHECK_HEARTBEAT,
+            heartbeat=cfg.EMAIL_REPLY_CHECK_HEARTBEAT,
             use_idle=cfg.EMAIL_REPLY_IMAP_USE_IDLE,
             connection_max_lifetime=cfg.EMAIL_REPLY_CONNECTION_MAX_LIFETIME,
             # FIXME - G.M - 2017-11-15 - proper tracim url formatting

--- a/tracim/tracim/lib/daemons.py
+++ b/tracim/tracim/lib/daemons.py
@@ -174,6 +174,8 @@ class MailFetcherDaemon(Daemon):
             use_ssl=cfg.EMAIL_REPLY_IMAP_USE_SSL,
             folder=cfg.EMAIL_REPLY_IMAP_FOLDER,
             delay=cfg.EMAIL_REPLY_CHECK_HEARTBEAT,
+            use_idle=cfg.EMAIL_REPLY_IMAP_USE_IDLE,
+            connection_max_lifetime=cfg.EMAIL_REPLY_CONNECTION_MAX_LIFETIME,
             # FIXME - G.M - 2017-11-15 - proper tracim url formatting
             endpoint=cfg.WEBSITE_BASE_URL + "/events",
             token=cfg.EMAIL_REPLY_TOKEN,

--- a/tracim/tracim/lib/email_fetcher.py
+++ b/tracim/tracim/lib/email_fetcher.py
@@ -161,7 +161,7 @@ class MailFetcher(object):
         folder: str,
         use_idle: bool,
         connection_max_lifetime: int,
-        delay: int,
+        heartbeat: int,
         endpoint: str,
         token: str,
         use_html_parsing: bool,
@@ -179,7 +179,7 @@ class MailFetcher(object):
         :param use_ssl: use imap over ssl connection
         :param folder: mail folder where new mail are fetched
         :param use_idle: use IMAP IDLE(server notification) when available
-        :param delay: seconds to wait before fetching new mail again
+        :param heartbeat: seconds to wait before fetching new mail again
         :param connection_max_lifetime: maximum duration allowed for a connection.
            connection is automatically renew when his lifetime excess this value
         :param endpoint: tracim http endpoint where decoded mail are send.
@@ -193,7 +193,7 @@ class MailFetcher(object):
         self.password = password
         self.use_ssl = use_ssl
         self.folder = folder
-        self.delay = delay
+        self.heartbeat = heartbeat
         self.use_idle = use_idle
         self.connection_max_lifetime = connection_max_lifetime
         self.endpoint = endpoint
@@ -217,8 +217,8 @@ class MailFetcher(object):
             except Exception as e:
                 log = 'Fail to connect to IMAP {}'
                 logger.error(self, log.format(e.__str__()))
-                logger.debug(self, 'sleep for {}'.format(self.delay))
-                time.sleep(self.delay)
+                logger.debug(self, 'sleep for {}'.format(self.heartbeat))
+                time.sleep(self.heartbeat)
                 continue
 
             # fetching
@@ -250,8 +250,8 @@ class MailFetcher(object):
                                   'support it, use polling instead.'
                             logger.warning(self, log)
                         # normal polling mode : sleep a define duration
-                        logger.debug(self, 'sleep for {}'.format(self.delay))
-                        time.sleep(self.delay)
+                        logger.debug(self, 'sleep for {}'.format(self.heartbeat))
+                        time.sleep(self.heartbeat)
 
                 logger.debug(self,"Lifetime limit excess, Renew connection")
             except filelock.Timeout as e:

--- a/tracim/tracim/lib/email_fetcher.py
+++ b/tracim/tracim/lib/email_fetcher.py
@@ -245,6 +245,10 @@ class MailFetcher(object):
                         )
                         imapc.idle_done()
                     else:
+                        if self.use_idle and not imapc.has_capability('IDLE'):
+                            log = 'IDLE mode activated but server do not' \
+                                  'support it, use polling instead.'
+                            logger.warning(self, log)
                         # normal polling mode : sleep a define duration
                         logger.debug(self, 'sleep for {}'.format(self.delay))
                         time.sleep(self.delay)

--- a/tracim/tracim/lib/email_fetcher.py
+++ b/tracim/tracim/lib/email_fetcher.py
@@ -196,7 +196,7 @@ class MailFetcher(object):
         logger.info(self, 'Starting MailFetcher')
         while self._is_active:
             try:
-                imapc = IMAPClient(self.host, ssl=self.use_ssl)
+                imapc = IMAPClient(self.host, self.port, ssl=self.use_ssl)
                 imapc.login(self.user, self.password)
                 # select mailbox
                 logger.debug(self, 'Select folder {}'.format(

--- a/tracim/tracim/lib/email_fetcher.py
+++ b/tracim/tracim/lib/email_fetcher.py
@@ -332,8 +332,10 @@ class MailFetcher(object):
     def stop(self) -> None:
         self._is_active = False
 
-    def _fetch(self, imapc: imapclient.IMAPClient) \
-            -> typing.List[MessageContainer]:
+    def _fetch(
+        self, 
+        imapc: imapclient.IMAPClient,
+    ) -> typing.List[MessageContainer]:
         """
         Get news message from mailbox
         :return: list of new mails


### PR DESCRIPTION
- Use imapclient instead of imaplib : more pythonic lib
- IDLE Imap feature option
- Don't recreate connection each time, stay in connection up to 'connection_max_lifetime'
- renaming : delay->heartbeat
- Better exceptions : more precise.