### PR TITLE
Mail fetcher rely only on checked flag.

### DIFF
--- a/tracim/tracim/lib/email_fetcher.py
+++ b/tracim/tracim/lib/email_fetcher.py
@@ -296,7 +296,8 @@ class MailFetcher(object):
 
             except BadIMAPFetchResponse as e:
                 log = 'Imap Fetch command return bad response.' \
-                      'Is someone else connected to the mailbox ?'
+                      'Is someone else connected to the mailbox ?: ' \
+                      '{}'
                 logger.error(self, log.format(e.__str__()))
             # Others
             except Exception as e:
@@ -372,7 +373,8 @@ class MailFetcher(object):
                 # This should happen only when someone-else use the mailbox
                 # at the same time of the fetcher.
                 # see https://github.com/mjs/imapclient/issues/334
-                raise BadIMAPFetchResponse from e
+                except_msg = 'fetch response : {}'.format(str(data))
+                raise BadIMAPFetchResponse(except_msg) from e
 
             msg_container = MessageContainer(msg, msgid)
             messages.append(msg_container)
@@ -398,7 +400,7 @@ class MailFetcher(object):
         #  if no from address for example) and catch it here
         while mails:
             mail = mails.pop()
-            body =  mail.get_body(
+            body = mail.get_body(
                 use_html_parsing=self.use_html_parsing,
                 use_txt_parsing=self.use_txt_parsing,
             )

--- a/tracim/tracim/lib/email_fetcher.py
+++ b/tracim/tracim/lib/email_fetcher.py
@@ -27,6 +27,7 @@ CONTENT_TYPE_TEXT_PLAIN = 'text/plain'
 CONTENT_TYPE_TEXT_HTML = 'text/html'
 
 IMAP_CHECKED_FLAG = imapclient.FLAGGED
+IMAP_SEEN_FLAG = imapclient.SEEN
 
 MAIL_FETCHER_FILELOCK_TIMEOUT = 10
 MAIL_FETCHER_CONNECTION_TIMEOUT = 60*3
@@ -441,6 +442,7 @@ class MailFetcher(object):
                 # Flag all correctly checked mail
                 if r.status_code in [200, 204, 400]:
                     imapc.add_flags((mail.uid,), IMAP_CHECKED_FLAG)
+                    imapc.add_flags((mail.uid,), IMAP_SEEN_FLAG)
             # TODO - G.M - Verify exception correctly works
             except requests.exceptions.Timeout as e:
                 log = 'Timeout error to transmit fetched mail to tracim : {}'


### PR DESCRIPTION
- Do not rely anymore on "seen" flag (buggy) for mail fetcher.
- Explicit Exception when strange behaviour of "fetch" command happend (see https://github.com/mjs/imapclient/issues/334)