### PR TITLE
add copy method into tracim contentAPI and COPY support for webdav

### DIFF
--- a/tracim/tracim/lib/content.py
+++ b/tracim/tracim/lib/content.py
@@ -906,9 +906,13 @@ class ContentApi(object):
         content.parent = parent
         content.workspace = workspace
         content.label = label
-        content.revision_type = ActionDescription.MOVE
+        content.revision_type = ActionDescription.COPY
+        content.properties['origin'] = {
+            'content': item.id,
+            'revision' : item.last_revision.revision_id,
+        }
         DBSession.add(content)
-        self.save(content, ActionDescription.MOVE, do_notify=do_notify)
+        self.save(content, ActionDescription.COPY, do_notify=do_notify)
 
     def move_recursively(self, item: Content,
                          new_parent: Content, new_workspace: Workspace):

--- a/tracim/tracim/lib/content.py
+++ b/tracim/tracim/lib/content.py
@@ -867,6 +867,15 @@ class ContentApi(object):
         new_label: str=None,
         do_notify: bool=True,
     ) -> Content:
+        """
+        Copy nearly all content, revision included. Children not included, see
+        "copy_children" for this.
+        :param item: Item to copy
+        :param new_parent: new parent of the new copied item
+        :param new_label: new label of the new copied item
+        :param do_notify: notify copy or not
+        :return: Newly copied item
+        """
         if (not new_parent and not new_label) or (new_parent == item.parent and new_label == item.label):  # nopep8
             # TODO - G.M - 08-03-2018 - Use something else than value error
             raise ValueError("You can't copy file into itself")
@@ -905,13 +914,13 @@ class ContentApi(object):
         content.revision_type = ActionDescription.COPY
         content.properties['origin'] = {
             'content': item.id,
-            'revision' : item.last_revision.revision_id,
+            'revision': item.last_revision.revision_id,
         }
         DBSession.add(content)
         self.save(content, ActionDescription.COPY, do_notify=do_notify)
         return content
 
-    def copy_children(self, origin_content:Content, new_content: Content):
+    def copy_children(self, origin_content: Content, new_content: Content):
         for child in origin_content.children:
             self.copy(child, new_content)
 

--- a/tracim/tracim/lib/content.py
+++ b/tracim/tracim/lib/content.py
@@ -884,6 +884,7 @@ class ContentApi(object):
             label = item.label
 
         with DBSession.no_autoflush:
+
             file = self.create(
                 content_type=item.type,
                 workspace=workspace,
@@ -898,6 +899,12 @@ class ContentApi(object):
                     item.file_name,
                     item.file_mimetype,
                     item.depot_file.file
+                )
+            for child in item.get_comments():
+                self.copy(child,
+                          new_parent=file,
+                          do_notify=False,
+                          do_save=False,
                 )
         if do_save:
             self.save(file, ActionDescription.CREATION, do_notify=do_notify)

--- a/tracim/tracim/lib/content.py
+++ b/tracim/tracim/lib/content.py
@@ -865,6 +865,7 @@ class ContentApi(object):
         item: Content,
         new_parent: Content=None,
         new_label: str=None,
+        do_save: bool=True,
         do_notify: bool=True,
     ) -> Content:
         """
@@ -891,20 +892,11 @@ class ContentApi(object):
         else:
             label = item.label
 
-        # INFO - G.M - 15-03-2018 - Copy content with first_revision
-        # to have consistent content
         content = Content()
-        cpy_rev = ContentRevisionRO.copy(item.first_revision, parent)
-        content.revisions.append(cpy_rev)
-        DBSession.add(content)
-
-        # INFO - G.M - 15-03-2018 - Add all older revision (history)
+        # INFO - G.M - 15-03-2018 - Add all revisions (history)
         for rev in item.revisions:
-            if rev == item.first_revision:
-                continue
             cpy_rev = ContentRevisionRO.copy(rev, parent)
             content.revisions.append(cpy_rev)
-            DBSession.add(content)
 
         # INFO - GM - 15-03-2018 - add "copy" revision
         content.new_revision()
@@ -916,8 +908,8 @@ class ContentApi(object):
             'content': item.id,
             'revision': item.last_revision.revision_id,
         }
-        DBSession.add(content)
-        self.save(content, ActionDescription.COPY, do_notify=do_notify)
+        if do_save:
+            self.save(content, ActionDescription.COPY, do_notify=do_notify)
         return content
 
     def copy_children(self, origin_content: Content, new_content: Content):

--- a/tracim/tracim/lib/content.py
+++ b/tracim/tracim/lib/content.py
@@ -897,9 +897,10 @@ class ContentApi(object):
             content.revisions.append(cpy_rev)
             DBSession.add(content)
 
+        # TODO - G.M - 15-03-2018 - Child copy broken !
         # INFO - G.M - 15-03-2018 - copy childrens (comments and others things)
-        for child in item.children:
-            self.copy(child, content)
+        # for child in item.children:
+        #    self.copy(child, content)
 
         # INFO - GM - 15-03-2018 - add "copy" revision
         content.new_revision()

--- a/tracim/tracim/lib/content.py
+++ b/tracim/tracim/lib/content.py
@@ -894,21 +894,21 @@ class ContentApi(object):
 
         content = item.copy(parent)
         # INFO - GM - 15-03-2018 - add "copy" revision
-        content.new_revision()
-        content.parent = parent
-        content.workspace = workspace
-        content.label = label
-        content.revision_type = ActionDescription.COPY
-        content.properties['origin'] = {
-            'content': item.id,
-            'revision': item.last_revision.revision_id,
-        }
+        with new_revision(content, force_create_new_revision=True) as rev:
+            rev.parent = parent
+            rev.workspace = workspace
+            rev.label = label
+            rev.revision_type = ActionDescription.COPY
+            rev.properties['origin'] = {
+                'content': item.id,
+                'revision': item.last_revision.revision_id,
+            }
         if do_save:
             self.save(content, ActionDescription.COPY, do_notify=do_notify)
         return content
 
     def copy_children(self, origin_content: Content, new_content: Content):
-        for child in origin_content.children:
+       for child in origin_content.children:
             self.copy(child, new_content)
 
     def move_recursively(self, item: Content,

--- a/tracim/tracim/lib/content.py
+++ b/tracim/tracim/lib/content.py
@@ -866,7 +866,7 @@ class ContentApi(object):
         new_parent: Content=None,
         new_label: str=None,
         do_notify: bool=True,
-    ) -> None:
+    ) -> Content:
         if (not new_parent and not new_label) or (new_parent == item.parent and new_label == item.label):  # nopep8
             # TODO - G.M - 08-03-2018 - Use something else than value error
             raise ValueError("You can't copy file into itself")
@@ -897,11 +897,6 @@ class ContentApi(object):
             content.revisions.append(cpy_rev)
             DBSession.add(content)
 
-        # TODO - G.M - 15-03-2018 - Child copy broken !
-        # INFO - G.M - 15-03-2018 - copy childrens (comments and others things)
-        # for child in item.children:
-        #    self.copy(child, content)
-
         # INFO - GM - 15-03-2018 - add "copy" revision
         content.new_revision()
         content.parent = parent
@@ -914,6 +909,11 @@ class ContentApi(object):
         }
         DBSession.add(content)
         self.save(content, ActionDescription.COPY, do_notify=do_notify)
+        return content
+
+    def copy_children(self, origin_content:Content, new_content: Content):
+        for child in origin_content.children:
+            self.copy(child, new_content)
 
     def move_recursively(self, item: Content,
                          new_parent: Content, new_workspace: Workspace):

--- a/tracim/tracim/lib/content.py
+++ b/tracim/tracim/lib/content.py
@@ -866,8 +866,9 @@ class ContentApi(object):
         new_parent: Content=None,
         new_label: str=None,
         do_save: bool=True,
+        do_notify: bool=True,
     ) -> None:
-        if not new_parent and not new_label:
+        if (not new_parent and not new_label) or (new_parent == item.parent and new_label == item.label):  # nopep8
             # TODO - G.M - 08-03-2018 - Use something else than value error
             raise ValueError("You can't copy file into itself")
         if new_parent:
@@ -899,7 +900,7 @@ class ContentApi(object):
                     item.depot_file.file
                 )
         if do_save:
-            self.save(file, ActionDescription.CREATION, do_notify=True)
+            self.save(file, ActionDescription.CREATION, do_notify=do_notify)
 
     def move_recursively(self, item: Content,
                          new_parent: Content, new_workspace: Workspace):

--- a/tracim/tracim/lib/content.py
+++ b/tracim/tracim/lib/content.py
@@ -908,7 +908,7 @@ class ContentApi(object):
         return content
 
     def copy_children(self, origin_content: Content, new_content: Content):
-       for child in origin_content.children:
+        for child in origin_content.children:
             self.copy(child, new_content)
 
     def move_recursively(self, item: Content,

--- a/tracim/tracim/lib/content.py
+++ b/tracim/tracim/lib/content.py
@@ -892,12 +892,7 @@ class ContentApi(object):
         else:
             label = item.label
 
-        content = Content()
-        # INFO - G.M - 15-03-2018 - Add all revisions (history)
-        for rev in item.revisions:
-            cpy_rev = ContentRevisionRO.copy(rev, parent)
-            content.revisions.append(cpy_rev)
-
+        content = item.copy(parent)
         # INFO - GM - 15-03-2018 - add "copy" revision
         content.new_revision()
         content.parent = parent

--- a/tracim/tracim/lib/content.py
+++ b/tracim/tracim/lib/content.py
@@ -886,11 +886,7 @@ class ContentApi(object):
         else:
             workspace = item.workspace
             parent = item.parent
-
-        if new_label:
-            label = new_label
-        else:
-            label = item.label
+        label = new_label or item.label
 
         content = item.copy(parent)
         # INFO - GM - 15-03-2018 - add "copy" revision

--- a/tracim/tracim/lib/webdav/design.py
+++ b/tracim/tracim/lib/webdav/design.py
@@ -120,7 +120,8 @@ _LABELS = {
     'unarchiving': 'Item unarchived',
     'undeletion': 'Item undeleted',
     'move': 'Item moved',
-    'comment': 'Comment'
+    'comment': 'Comment',
+    'copy' : 'Item copied',
 }
 
 

--- a/tracim/tracim/lib/webdav/sql_resources.py
+++ b/tracim/tracim/lib/webdav/sql_resources.py
@@ -1007,6 +1007,14 @@ class File(DAVNonCollection):
 
     def copyMoveSingle(self, destpath, isMove):
         if isMove:
+            # INFO - G.M - 12-03-2018 - This case should not happen
+            # As far as moveRecursive method exist, all move should not go
+            # through this method. If such case appear, try replace this to :
+            ####
+            # self.move_file(destpath)
+            # return
+            ####
+
             raise NotImplemented
 
         new_file_name = None

--- a/tracim/tracim/lib/webdav/sql_resources.py
+++ b/tracim/tracim/lib/webdav/sql_resources.py
@@ -1039,12 +1039,12 @@ class File(DAVNonCollection):
         )
         workspace = self.content.workspace
         parent = self.content.parent
-        self.content_api.copy(
+        new_content = self.content_api.copy(
             item=self.content,
             new_label=new_file_name,
             new_parent=destination_parent,
         )
-
+        self.content_api.copy_children(self.content, new_content)
         transaction.commit()
 
     def supportRecursiveMove(self, destPath):

--- a/tracim/tracim/lib/webdav/sql_resources.py
+++ b/tracim/tracim/lib/webdav/sql_resources.py
@@ -1005,6 +1005,40 @@ class File(DAVNonCollection):
 
         transaction.commit()
 
+    def copyMoveSingle(self, destpath, isMove):
+        if isMove:
+            raise NotImplemented
+
+        new_file_name = None
+        new_file_extension = None
+
+        # Inspect destpath
+        if basename(destpath) != self.getDisplayName():
+            new_given_file_name = transform_to_bdd(basename(destpath))
+            new_file_name, new_file_extension = \
+                os.path.splitext(new_given_file_name)
+
+        workspace_api = WorkspaceApi(self.user)
+        content_api = ContentApi(self.user)
+        destination_workspace = self.provider.get_workspace_from_path(
+            destpath,
+            workspace_api,
+        )
+        destination_parent = self.provider.get_parent_from_path(
+            destpath,
+            content_api,
+            destination_workspace,
+        )
+        workspace = self.content.workspace
+        parent = self.content.parent
+        self.content_api.copy(
+            item=self.content,
+            new_label=new_file_name,
+            new_parent=destination_parent,
+        )
+
+        transaction.commit()
+
     def supportRecursiveMove(self, destPath):
         return True
 

--- a/tracim/tracim/model/__init__.py
+++ b/tracim/tracim/model/__init__.py
@@ -120,7 +120,10 @@ def prevent_content_revision_delete(session: Session, flush_context: UOWTransact
 
 
 @contextmanager
-def new_revision(content: Content) -> Content:
+def new_revision(
+        content: Content,
+        force_create_new_revision: bool=False,
+) -> Content:
     """
     Prepare context to update a Content. It will add a new updatable revision to the content.
     :param content: Content instance to update
@@ -128,7 +131,8 @@ def new_revision(content: Content) -> Content:
     """
     with DBSession.no_autoflush:
         try:
-            if inspect(content.revision).has_identity:
+            if force_create_new_revision \
+                    or inspect(content.revision).has_identity:
                 content.new_revision()
             RevisionsIntegrity.add_to_updatable(content.revision)
             yield content

--- a/tracim/tracim/model/data.py
+++ b/tracim/tracim/model/data.py
@@ -640,6 +640,36 @@ class ContentRevisionRO(DeclarativeBase):
 
         return new_rev
 
+    @classmethod
+    def copy(
+            cls,
+            revision: 'ContentRevisionRO',
+            parent: 'Content'
+    ) -> 'ContentRevisionRO':
+
+        copy_rev = cls()
+        import copy
+        copy_columns = cls._cloned_columns
+        for column_name in copy_columns:
+            # INFO - G-M - 15-03-2018 - set correct parent
+            if column_name == 'parent_id':
+                column_value = copy.copy(parent.id)
+            elif column_name == 'parent':
+                column_value = copy.copy(parent)
+            else:
+                column_value = copy.copy(getattr(revision, column_name))
+            setattr(copy_rev, column_name, column_value)
+
+        # copy attached_file
+        if revision.depot_file:
+            copy_rev.depot_file = FileIntent(
+                revision.depot_file.file.read(),
+                revision.file_name,
+                revision.file_mimetype,
+            )
+        return copy_rev
+
+
     def __setattr__(self, key: str, value: 'mixed'):
         """
         ContentRevisionUpdateError is raised if tried to update column and revision own identity

--- a/tracim/tracim/model/data.py
+++ b/tracim/tracim/model/data.py
@@ -1293,6 +1293,13 @@ class Content(DeclarativeBase):
         cid = content.content_id
         return url_template.format(wid=wid, fid=fid, ctype=ctype, cid=cid)
 
+    def copy(self, parent):
+        cpy_content = Content()
+        for rev in self.revisions:
+            cpy_rev = ContentRevisionRO.copy(rev, parent)
+            cpy_content.revisions.append(cpy_rev)
+        return cpy_content
+
 
 class RevisionReadStatus(DeclarativeBase):
 

--- a/tracim/tracim/model/data.py
+++ b/tracim/tracim/model/data.py
@@ -1117,7 +1117,7 @@ class Content(DeclarativeBase):
         revisions = sorted(self.revisions, key=lambda revision: revision.revision_id)
         return revisions[-1]
 
-    def new_revision(self) -> None:
+    def new_revision(self) -> ContentRevisionRO:
         """
         Return and assign to this content a new revision.
         If it's a new content, revision is totally new.

--- a/tracim/tracim/model/data.py
+++ b/tracim/tracim/model/data.py
@@ -204,6 +204,7 @@ class ActionDescription(object):
     - closed-deprecated
     """
 
+    COPY = 'copy'
     ARCHIVING = 'archiving'
     COMMENT = 'content-comment'
     CREATION = 'creation'
@@ -225,7 +226,8 @@ class ActionDescription(object):
         'status-update': 'fa-random',
         'unarchiving': 'fa-file-archive-o',
         'undeletion': 'fa-trash-o',
-        'move': 'fa-arrows'
+        'move': 'fa-arrows',
+        'copy': 'fa-files-o',
     }
 
     _LABELS = {
@@ -238,7 +240,8 @@ class ActionDescription(object):
         'status-update': l_('New status'),
         'unarchiving': l_('Item unarchived'),
         'undeletion': l_('Item undeleted'),
-        'move': l_('Item moved')
+        'move': l_('Item moved'),
+        'copy': l_('Item copied'),
     }
 
     def __init__(self, id):
@@ -259,7 +262,9 @@ class ActionDescription(object):
                 cls.STATUS_UPDATE,
                 cls.UNARCHIVING,
                 cls.UNDELETION,
-                cls.MOVE]
+                cls.MOVE,
+                cls.COPY,
+                ]
 
 
 class ContentStatus(object):
@@ -514,6 +519,11 @@ class ContentChecker(object):
                 return False
             return True
 
+        # TODO - G.M - 15-03-2018 - Choose only correct Content-type for origin
+        # Only content who can be copied need this
+        if item.type == ContentType.Any:
+            if 'origin' in properties.keys():
+                return True
         raise NotImplementedError
 
     @classmethod

--- a/tracim/tracim/model/data.py
+++ b/tracim/tracim/model/data.py
@@ -590,7 +590,6 @@ class ContentRevisionRO(DeclarativeBase):
         'is_archived',
         'is_deleted',
         'label',
-        'node',
         'owner',
         'owner_id',
         'parent',

--- a/tracim/tracim/tests/library/test_content_api.py
+++ b/tracim/tracim/tests/library/test_content_api.py
@@ -428,7 +428,7 @@ class TestContentApi(BaseTest, TestStandard):
         assert text_file != text_file_copy
         assert text_file_copy.content_id != text_file.content_id
         assert text_file_copy.workspace_id == workspace2.workspace_id
-        assert text_file_copy.depot_file.file.read() == text_file.depot_file.file.read()
+        assert text_file_copy.depot_file.file.read() == text_file.depot_file.file.read()   # nopep8
         assert text_file_copy.depot_file.path != text_file.depot_file.path
         assert text_file_copy.label == 'test_file_copy'
         assert text_file_copy.type == text_file.type
@@ -516,7 +516,7 @@ class TestContentApi(BaseTest, TestStandard):
         assert text_file != text_file_copy
         assert text_file_copy.content_id != text_file.content_id
         assert text_file_copy.workspace_id == workspace2.workspace_id
-        assert text_file_copy.depot_file.file.read() == text_file.depot_file.file.read()
+        assert text_file_copy.depot_file.file.read() == text_file.depot_file.file.read()  # nopep8
         assert text_file_copy.depot_file.path != text_file.depot_file.path
         assert text_file_copy.label == text_file.label
         assert text_file_copy.type == text_file.type
@@ -598,7 +598,7 @@ class TestContentApi(BaseTest, TestStandard):
         assert text_file != text_file_copy
         assert text_file_copy.content_id != text_file.content_id
         assert text_file_copy.workspace_id == workspace.workspace_id
-        assert text_file_copy.depot_file.file.read() == text_file.depot_file.file.read()
+        assert text_file_copy.depot_file.file.read() == text_file.depot_file.file.read()  # nopep8
         assert text_file_copy.depot_file.path != text_file.depot_file.path
         assert text_file_copy.label == 'test_file_copy'
         assert text_file_copy.type == text_file.type

--- a/tracim/tracim/tests/library/test_content_api.py
+++ b/tracim/tracim/tests/library/test_content_api.py
@@ -425,15 +425,17 @@ class TestContentApi(BaseTest, TestStandard):
         )
         assert text_file != text_file_copy
         assert text_file_copy.content_id != text_file.content_id
-        assert text_file_copy.workspace == workspace2
-        assert text_file_copy.depot_file != text_file.depot_file
+        assert text_file_copy.workspace_id == workspace2.workspace_id
+        assert text_file_copy.depot_file.file.read() == text_file.depot_file.file.read()
+        assert text_file_copy.depot_file.path != text_file.depot_file.path
         assert text_file_copy.label == 'test_file_copy'
         assert text_file_copy.type == text_file.type
-        assert text_file_copy.parent == folderb
-        assert text_file_copy.owner == user2
+        assert text_file_copy.parent.content_id == folderb.content_id
+        assert text_file_copy.owner.user_id == user.user_id
         assert text_file_copy.description == text_file.description
         assert text_file_copy.file_extension == text_file.file_extension
         assert text_file_copy.file_mimetype == text_file.file_mimetype
+        assert text_file_copy.revision_type == ActionDescription.COPY
 
     def test_unit_copy_file__same_label_different_parent_ok(self):
         uapi = UserApi(None)
@@ -506,15 +508,17 @@ class TestContentApi(BaseTest, TestStandard):
         text_file_copy = api2.get_one_by_label_and_parent('test_file', folderb)
         assert text_file != text_file_copy
         assert text_file_copy.content_id != text_file.content_id
-        assert text_file_copy.workspace == workspace2
-        assert text_file_copy.depot_file != text_file.depot_file
+        assert text_file_copy.workspace_id == workspace2.workspace_id
+        assert text_file_copy.depot_file.file.read() == text_file.depot_file.file.read()
+        assert text_file_copy.depot_file.path != text_file.depot_file.path
         assert text_file_copy.label == text_file.label
         assert text_file_copy.type == text_file.type
-        assert text_file_copy.parent == folderb
-        assert text_file_copy.owner == user2
+        assert text_file_copy.parent.content_id == folderb.content_id
+        assert text_file_copy.owner.user_id == user.user_id
         assert text_file_copy.description == text_file.description
         assert text_file_copy.file_extension == text_file.file_extension
         assert text_file_copy.file_mimetype == text_file.file_mimetype
+        assert text_file_copy.revision_type == ActionDescription.COPY
 
     def test_unit_copy_file_different_label_same_parent_ok(self):
         uapi = UserApi(None)
@@ -583,15 +587,17 @@ class TestContentApi(BaseTest, TestStandard):
         )
         assert text_file != text_file_copy
         assert text_file_copy.content_id != text_file.content_id
-        assert text_file_copy.workspace == workspace
-        assert text_file_copy.depot_file != text_file.depot_file
+        assert text_file_copy.workspace_id == workspace.workspace_id
+        assert text_file_copy.depot_file.file.read() == text_file.depot_file.file.read()
+        assert text_file_copy.depot_file.path != text_file.depot_file.path
         assert text_file_copy.label == 'test_file_copy'
         assert text_file_copy.type == text_file.type
-        assert text_file_copy.parent == foldera
-        assert text_file_copy.owner == user2
+        assert text_file_copy.parent.content_id == foldera.content_id
+        assert text_file_copy.owner.user_id == user.user_id
         assert text_file_copy.description == text_file.description
         assert text_file_copy.file_extension == text_file.file_extension
         assert text_file_copy.file_mimetype == text_file.file_mimetype
+        assert text_file_copy.revision_type == ActionDescription.COPY
 
     def test_mark_read__workspace(self):
         uapi = UserApi(None)

--- a/tracim/tracim/tests/library/test_content_api.py
+++ b/tracim/tracim/tests/library/test_content_api.py
@@ -419,10 +419,12 @@ class TestContentApi(BaseTest, TestStandard):
             new_label='test_file_copy'
         )
 
+        transaction.commit()
         text_file_copy = api2.get_one_by_label_and_parent(
             'test_file_copy',
-            folderb
+            folderb,
         )
+
         assert text_file != text_file_copy
         assert text_file_copy.content_id != text_file.content_id
         assert text_file_copy.workspace_id == workspace2.workspace_id
@@ -436,6 +438,7 @@ class TestContentApi(BaseTest, TestStandard):
         assert text_file_copy.file_extension == text_file.file_extension
         assert text_file_copy.file_mimetype == text_file.file_mimetype
         assert text_file_copy.revision_type == ActionDescription.COPY
+        assert len(text_file_copy.revisions) == len(text_file.revisions) + 1
 
     def test_unit_copy_file__same_label_different_parent_ok(self):
         uapi = UserApi(None)
@@ -499,13 +502,17 @@ class TestContentApi(BaseTest, TestStandard):
             'folder b',
             True
         )
-
         api2.copy(
             item=text_file,
             new_parent=folderb,
         )
 
-        text_file_copy = api2.get_one_by_label_and_parent('test_file', folderb)
+        transaction.commit()
+        text_file_copy = api2.get_one_by_label_and_parent(
+            'test_file',
+            folderb,
+        )
+
         assert text_file != text_file_copy
         assert text_file_copy.content_id != text_file.content_id
         assert text_file_copy.workspace_id == workspace2.workspace_id
@@ -519,6 +526,7 @@ class TestContentApi(BaseTest, TestStandard):
         assert text_file_copy.file_extension == text_file.file_extension
         assert text_file_copy.file_mimetype == text_file.file_mimetype
         assert text_file_copy.revision_type == ActionDescription.COPY
+        assert len(text_file_copy.revisions) == len(text_file.revisions) + 1
 
     def test_unit_copy_file_different_label_same_parent_ok(self):
         uapi = UserApi(None)
@@ -581,10 +589,12 @@ class TestContentApi(BaseTest, TestStandard):
             new_label='test_file_copy'
         )
 
+        transaction.commit()
         text_file_copy = api2.get_one_by_label_and_parent(
             'test_file_copy',
-            foldera
+            foldera,
         )
+
         assert text_file != text_file_copy
         assert text_file_copy.content_id != text_file.content_id
         assert text_file_copy.workspace_id == workspace.workspace_id
@@ -598,6 +608,7 @@ class TestContentApi(BaseTest, TestStandard):
         assert text_file_copy.file_extension == text_file.file_extension
         assert text_file_copy.file_mimetype == text_file.file_mimetype
         assert text_file_copy.revision_type == ActionDescription.COPY
+        assert len(text_file_copy.revisions) == len(text_file.revisions) + 1
 
     def test_mark_read__workspace(self):
         uapi = UserApi(None)

--- a/tracim/tracim/tests/models/test_content_revision.py
+++ b/tracim/tracim/tests/models/test_content_revision.py
@@ -13,7 +13,13 @@ from tracim.tests import TestStandard, BaseTest
 class TestContentRevision(BaseTest, TestStandard):
 
     def _new_from(self, revision):
-        excluded_columns = ('revision_id', '_sa_instance_state', 'depot_file')
+        excluded_columns = (
+            'revision_id',
+            '_sa_instance_state',
+            'depot_file',
+            'node',
+            'revision_read_statuses',
+        )
         revision_columns = [attr.key for attr in inspect(revision).attrs if not attr.key in excluded_columns]
         new_revision = ContentRevisionRO()
 


### PR DESCRIPTION
Fix https://github.com/tracim/tracim/issues/540 .

**About contentAPI copy feature into tracim :**
Copy feature support copy of all type of document, copy are not exact copy, history and comments are not added to the copy. Copy is same as a special case of "creation" .

**About COPY and webdav**

Webdav support now COPY feature using copy method of tracim contentAPI.
In nautilus 3.26 , recursive COPY of folder work.

closes #540
closes #543
closes #552
