### PR TITLE
WIP: Fix webdav for davfs2

### DIFF
--- a/tracim/tracim/lib/webdav/sql_resources.py
+++ b/tracim/tracim/lib/webdav/sql_resources.py
@@ -215,14 +215,24 @@ class Workspace(DAVCollection):
         if resource:
             content = resource.content
 
-        return FakeFileStream(
-            file_name=file_name,
-            content_api=self.content_api,
-            workspace=self.workspace,
-            content=content,
-            parent=self.content,
-            path=self.path + '/' + file_name
-        )
+        if not content:
+            # INFO - G.M - 21-03-2018 create new empty file and commit it.
+            new_empty_file = FakeFileStream(
+                file_name=file_name,
+                content_api=self.content_api,
+                workspace=self.workspace,
+                content=content,
+                parent=self.content,
+                path=path,
+            )
+            new_empty_file.close()
+
+        # INFO - G.M - 21-03-2018 - Obtain true davFile from provider
+        resource = self.provider.getResourceInst(path, self.environ)
+        if not resource:
+            raise DAVError(HTTP_FORBIDDEN)
+        content = resource.content
+        return File(path=path, content=content,environ=self.environ)
 
     def createCollection(self, label: str) -> 'Folder':
         """

--- a/tracim/tracim/lib/webdav/sql_resources.py
+++ b/tracim/tracim/lib/webdav/sql_resources.py
@@ -24,7 +24,9 @@ from tracim.model.data import ContentType
 from tracim.lib.webdav.design import designThread, designPage
 
 from wsgidav import compat
-from wsgidav.dav_error import DAVError, HTTP_FORBIDDEN
+from wsgidav.dav_error import DAVError
+from wsgidav.dav_error import HTTP_FORBIDDEN
+from wsgidav.dav_error import HTTP_NOT_FOUND
 from wsgidav.dav_provider import DAVCollection, DAVNonCollection
 from wsgidav.dav_provider import _DAVResource
 from tracim.lib.webdav.utils import normpath
@@ -230,9 +232,9 @@ class Workspace(DAVCollection):
         # INFO - G.M - 21-03-2018 - Obtain true davFile from provider
         resource = self.provider.getResourceInst(path, self.environ)
         if not resource:
-            raise DAVError(HTTP_FORBIDDEN)
+            raise DAVError(HTTP_NOT_FOUND)
         content = resource.content
-        return File(path=path, content=content,environ=self.environ)
+        return File(path=path, content=content, environ=self.environ)
 
     def createCollection(self, label: str) -> 'Folder':
         """


### PR DESCRIPTION
davfs2 need a working "LOCK" (Doing a lock create automatically an empty file) . As method to create empty file doesn't return a 'File' type, automatic creation of new file when "LOCK" inexistent file in wsgidav failed. 

Return a valid File in method to create empty file resolve this issue.