### PR TITLE
Permit install tests packages

### DIFF
--- a/tracim/setup.py
+++ b/tracim/setup.py
@@ -59,6 +59,9 @@ setup(
     include_package_data=True,
     test_suite='nose.collector',
     tests_require=testpkgs,
+    extras_require={
+        'test': testpkgs,
+    },
     package_data={
         'tracim': [
             'i18n/*/LC_MESSAGES/*.mo',

--- a/uppgrade_caldavzap.sh
+++ b/uppgrade_caldavzap.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
+
 read -p "Delete actual tracim/tracim/public/caldavzap folder? " -n 1 -r
 echo    # (optional) move to a new line
+
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
     rm -r tracim/tracim/public/caldavzap
 fi
+
 git clone https://github.com/algoo/caldavzap.git tracim/tracim/public/caldavzap
 rm -rf tracim/tracim/public/caldavzap/.git


### PR DESCRIPTION
Our Jenkins build is broken because test package missing in docker image. To permit install them, put them in setup.py and update docker_tracim (https://github.com/tracim/docker_tracim/pull/11)