### PR TITLE
Fix/1318 fix docker missing reply email daemon

### DIFF
--- a/tools_docker/Debian_Uwsgi/Dockerfile
+++ b/tools_docker/Debian_Uwsgi/Dockerfile
@@ -51,6 +51,8 @@ RUN \
     uwsgi-plugin-python3 \
     redis-server \
     zlib1g-dev \
+    supervisor \
+    vim \
 # Install nodejs
     && curl -sL https://deb.nodesource.com/setup_8.x | bash - \
     && apt update \

--- a/tools_docker/Debian_Uwsgi/entrypoint.sh
+++ b/tools_docker/Debian_Uwsgi/entrypoint.sh
@@ -65,9 +65,24 @@ chown www-data:www-data -R /var/tracim
 
 # activate apache mods
 a2enmod proxy proxy_http proxy_ajp rewrite deflate headers proxy_html dav_fs dav
+
 # starting services
 service redis-server start  # async email sending
 service apache2 restart
+
+# Activate daemon for reply by email
+if [ "$REPLY_BY_EMAIL" = "1" ];then
+    export TRACIM_CONF_PATH="/etc/tracim/development.ini"
+    nohup python3 /tracim/backend/daemons/mail_fetcher.py > /var/tracim/logs/mail_fetcher.log 2>&1 </dev/null &
+fi
+
+# Activate daemon for sending email in async
+if [ "$EMAIL_MODE_ASYNC" = "1" ];then
+    export TRACIM_CONF_PATH="/etc/tracim/development.ini"
+    nohup python3 /tracim/backend/daemons/mail_notifier.py > /var/tracim/logs/mail_notifier.log 2>&1 </dev/null &
+fi
+
+# Start tracim with webdav or not
 if [ "$START_WEBDAV" = "1" ]; then
     set +e
     service uwsgi restart

--- a/tools_docker/Debian_Uwsgi/entrypoint.sh
+++ b/tools_docker/Debian_Uwsgi/entrypoint.sh
@@ -63,7 +63,7 @@ mkdir -p /var/run/uwsgi/app/
 chown www-data:www-data -R /var/run/uwsgi
 chown www-data:www-data -R /var/tracim
 chmod +x /tracim/backend/daemons/mail_fetcher.py
-chmod +x /tracim/backend/daemons/mail_fetcher.py
+chmod +x /tracim/backend/daemons/mail_notifier.py
 
 # activate apache mods
 a2enmod proxy proxy_http proxy_ajp rewrite deflate headers proxy_html dav_fs dav

--- a/tools_docker/Debian_Uwsgi/entrypoint.sh
+++ b/tools_docker/Debian_Uwsgi/entrypoint.sh
@@ -62,6 +62,8 @@ fi
 mkdir -p /var/run/uwsgi/app/
 chown www-data:www-data -R /var/run/uwsgi
 chown www-data:www-data -R /var/tracim
+chmod +x /tracim/backend/daemons/mail_fetcher.py
+chmod +x /tracim/backend/daemons/mail_fetcher.py
 
 # activate apache mods
 a2enmod proxy proxy_http proxy_ajp rewrite deflate headers proxy_html dav_fs dav
@@ -69,17 +71,16 @@ a2enmod proxy proxy_http proxy_ajp rewrite deflate headers proxy_html dav_fs dav
 # starting services
 service redis-server start  # async email sending
 service apache2 restart
+supervisord -c /tracim/tools_docker/Debian_Uwsgi/supervisord_tracim.conf
 
 # Activate daemon for reply by email
 if [ "$REPLY_BY_EMAIL" = "1" ];then
-    export TRACIM_CONF_PATH="/etc/tracim/development.ini"
-    nohup python3 /tracim/backend/daemons/mail_fetcher.py > /var/tracim/logs/mail_fetcher.log 2>&1 </dev/null &
+    supervisorctl start tracim_mail_fetcher
 fi
 
 # Activate daemon for sending email in async
 if [ "$EMAIL_MODE_ASYNC" = "1" ];then
-    export TRACIM_CONF_PATH="/etc/tracim/development.ini"
-    nohup python3 /tracim/backend/daemons/mail_notifier.py > /var/tracim/logs/mail_notifier.log 2>&1 </dev/null &
+    supervisorctl start tracim_mail_notifier
 fi
 
 # Start tracim with webdav or not

--- a/tools_docker/Debian_Uwsgi/supervisord_tracim.conf
+++ b/tools_docker/Debian_Uwsgi/supervisord_tracim.conf
@@ -1,0 +1,48 @@
+; supervisor config file
+
+[unix_http_server]
+file=/var/run/supervisor.sock   ; (the path to the socket file)
+chmod=0700                       ; sockef file mode (default 0700)
+
+[supervisord]
+logfile=/var/tracim/log/supervisord.log ; (main log file;default $CWD/supervisord.log)
+pidfile=/var/run/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
+childlogdir=/var/tracim/log/supervisor            ; ('AUTO' child log dir, default $TEMP)
+
+; email notifier (if async email notification is enabled)
+[program:tracim_mail_notifier]
+directory=/tracim/backend/
+command=python3 /tracim/backend/daemons/mail_notifier.py
+stdout_logfile =/var/tracim/log/mail_notifier.log
+redirect_stderr=true
+autostart=false
+autorestart=false
+environment=TRACIM_CONF_PATH=/etc/tracim/development.ini
+
+; email fetcher (if email reply is enabled)
+[program:tracim_mail_fetcher]
+directory=/tracim/backend/
+command=python3 /tracim/backend/daemons/mail_fetcher.py
+stdout_logfile =/var/tracim/log/mail_fetcher.log
+redirect_stderr=true
+autostart=false
+autorestart=false
+environment=TRACIM_CONF_PATH=/etc/tracim/development.ini
+
+; the below section must remain in the config file for RPC
+; (supervisorctl/web interface) to work, additional interfaces may be
+; added by defining them in separate rpcinterface: sections
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///var/run/supervisor.sock ; use a unix:// URL  for a unix socket
+
+; The [include] section can just contain the "files" setting.  This
+; setting can list multiple files (separated by whitespace or
+; newlines).  It can also contain wildcards.  The filenames are
+; interpreted as relative to this file.  Included files *cannot*
+; include files themselves.
+
+[include]
+files = /etc/supervisor/conf.d/*.conf

--- a/tools_docker/Debian_Uwsgi/supervisord_tracim.conf
+++ b/tools_docker/Debian_Uwsgi/supervisord_tracim.conf
@@ -5,15 +5,15 @@ file=/var/run/supervisor.sock   ; (the path to the socket file)
 chmod=0700                       ; sockef file mode (default 0700)
 
 [supervisord]
-logfile=/var/tracim/log/supervisord.log ; (main log file;default $CWD/supervisord.log)
+logfile=/var/tracim/logs/supervisord.log ; (main log file;default $CWD/supervisord.log)
 pidfile=/var/run/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
-childlogdir=/var/tracim/log/supervisor            ; ('AUTO' child log dir, default $TEMP)
+childlogdir=/var/tracim/logs/supervisor            ; ('AUTO' child log dir, default $TEMP)
 
 ; email notifier (if async email notification is enabled)
 [program:tracim_mail_notifier]
 directory=/tracim/backend/
 command=python3 /tracim/backend/daemons/mail_notifier.py
-stdout_logfile =/var/tracim/log/mail_notifier.log
+stdout_logfile =/var/tracim/logs/mail_notifier.log
 redirect_stderr=true
 autostart=false
 autorestart=false
@@ -23,7 +23,7 @@ environment=TRACIM_CONF_PATH=/etc/tracim/development.ini
 [program:tracim_mail_fetcher]
 directory=/tracim/backend/
 command=python3 /tracim/backend/daemons/mail_fetcher.py
-stdout_logfile =/var/tracim/log/mail_fetcher.log
+stdout_logfile =/var/tracim/logs/mail_fetcher.log
 redirect_stderr=true
 autostart=false
 autorestart=false

--- a/tools_docker/Debian_Uwsgi/supervisord_tracim.conf
+++ b/tools_docker/Debian_Uwsgi/supervisord_tracim.conf
@@ -7,7 +7,7 @@ chmod=0700                       ; sockef file mode (default 0700)
 [supervisord]
 logfile=/var/tracim/logs/supervisord.log ; (main log file;default $CWD/supervisord.log)
 pidfile=/var/run/supervisord.pid ; (supervisord pidfile;default supervisord.pid)
-childlogdir=/var/tracim/logs/supervisor            ; ('AUTO' child log dir, default $TEMP)
+childlogdir=/var/tracim/logs/            ; ('AUTO' child log dir, default $TEMP)
 
 ; email notifier (if async email notification is enabled)
 [program:tracim_mail_notifier]

--- a/tools_docker/README.md
+++ b/tools_docker/README.md
@@ -25,6 +25,18 @@ Used port in container:
 
 * 80 (Tracim HTTP API and web user interface)
 
+If you want to use webdav:
+
+* START_WEBDAV=1
+
+If you want to use reply_by_email function:
+
+* REPLY_BY_EMAIL=1 (if email reply is enabled)
+
+If you want to use async for sendinf email
+
+* EMAIL_MODE_ASYNC=1 (for async email notification)
+
 #### Example commands
 
 To run tracim container with MySQL or PostgreSQL, you must set environment ``DATABASE_USER, DATABASE_PASSWORD, DATABASE_HOST, DATABASE_PORT, DATABASE_NAME`` variable.
@@ -48,6 +60,16 @@ Example with SQLite
     docker run -e DATABASE_TYPE=sqlite \
                -p 80:80 \
                -v /var/tracim/etc/:/etc/tracim -v /var/tracim/var:/var/tracim algoo/tracim
+               
+Exemple with SQlite, webdav, reply_by_email and email_mode_async
+
+    docker run -e DATABASE_TYPE=sqlite \
+               -e START_WEBDAV=1 \
+               -e REPLY_BY_EMAIL=1 \
+               -e EMAIL_MODE_ASYNC=1 \
+               -p 80:80 \
+               -v /var/tracim/etc/:/etc/tracim -v /var/tracim/var:/var/tracim algoo/tracim
+
 
 After execute one of these command, tracim will be available on your system on port 80.
 


### PR DESCRIPTION
Add:
- supervisord to start python service
- parameter in entrypoint
- new config file for supervisord

related to #1318 