### PR TITLE
Fix/1325 support content type alias in allowed content properties db

### DIFF
--- a/backend/tracim_backend/app_models/contents.py
+++ b/backend/tracim_backend/app_models/contents.py
@@ -223,13 +223,17 @@ class ContentTypeList(object):
         allowed_type_slug = [contents_type.slug for contents_type in self._content_types]  # nopep8
         return allowed_type_slug
 
+    def endpoint_allowed_types(self) -> typing.List[ContentType]:
+        content_types = self._content_types
+        content_types.extend(self._special_contents_types)
+        return content_types
+
     def endpoint_allowed_types_slug(self) -> typing.List[str]:
         """
         Same as restricted_allowed_types_slug but with special content_type
         included like comments.
         """
-        content_types = self._content_types
-        content_types.extend(self._special_contents_types)
+        content_types = self.endpoint_allowed_types()
         allowed_type_slug = [contents_type.slug for contents_type in content_types]  # nopep8
         return allowed_type_slug
 

--- a/backend/tracim_backend/models/data.py
+++ b/backend/tracim_backend/models/data.py
@@ -27,7 +27,8 @@ from sqlalchemy.types import Integer
 from sqlalchemy.types import Text
 from sqlalchemy.types import Unicode
 
-from tracim_backend.app_models.contents import ContentStatus, ContentType
+from tracim_backend.app_models.contents import ContentStatus
+from tracim_backend.app_models.contents import ContentType
 from tracim_backend.app_models.contents import content_status_list
 from tracim_backend.app_models.contents import content_type_list
 from tracim_backend.exceptions import ContentRevisionUpdateError

--- a/backend/tracim_backend/models/data.py
+++ b/backend/tracim_backend/models/data.py
@@ -27,7 +27,7 @@ from sqlalchemy.types import Integer
 from sqlalchemy.types import Text
 from sqlalchemy.types import Unicode
 
-from tracim_backend.app_models.contents import ContentStatus
+from tracim_backend.app_models.contents import ContentStatus, ContentType
 from tracim_backend.app_models.contents import content_status_list
 from tracim_backend.app_models.contents import content_type_list
 from tracim_backend.exceptions import ContentRevisionUpdateError
@@ -98,9 +98,9 @@ class Workspace(DeclarativeBase):
         """ this method is for interoperability with Content class"""
         return self.label
 
-    def get_allowed_content_types(self):
+    def get_allowed_content_types(self) -> typing.List[ContentType]:
         # @see Content.get_allowed_content_types()
-        return content_type_list.endpoint_allowed_types_slug()
+        return content_type_list.endpoint_allowed_types()
 
     def get_valid_children(
             self,


### PR DESCRIPTION
related to #1325 

use ContentType objet instead of slug in order to correctly support content-type legacy alias like "page" for allowed_content. 