### PR TITLE
Fix/1183 better log for sync/async mail

### DIFF
--- a/backend/development.ini.sample
+++ b/backend/development.ini.sample
@@ -207,8 +207,7 @@ email.processing_mode = sync
 
 ## available choice: True or False
 email.notification.activated = False
-## You can change file_path for mail-notifications.log
-; email.notification.log_file_path = /tmp/mail-notifications.log
+# You can activate for mail-notifications.log using 'tracim_notification' logger.
 
 ### SMTP ###
 email.notification.smtp.server = your_smtp_server
@@ -430,6 +429,9 @@ script_location = tracim_backend/migration
 ### LOGGERS ###
 [loggers]
 keys = root, tracim, sqlalchemy, alembic, hapic
+# add Tracim_notification logfile
+# this need to add tracim_notification handler and tracim_notification formatter
+; keys = root, tracim, sqlalchemy, alembic, hapic, tracim_notification
 
 [logger_root]
 level = INFO
@@ -455,6 +457,12 @@ level = DEBUG
 handlers =
 qualname = hapic
 
+[logger_tracim_notification]
+level = INFO
+handlers = tracim_notification
+qualname = tracim_notification
+propagate = 0
+
 ### FORMATTER ###
 # colored log formatter for console (do not work properly with file)
 # this need coloredlog python package, you can install it in venv
@@ -474,11 +482,17 @@ datefmt = %H:%M:%S
 format = %(asctime)s %(levelname)-5.5s [%(name)s:%(lineno)s][%(threadName)s] %(message)s
 datefmt = %H:%M:%S
 
+[formatter_tracim_notification]
+format = %(asctime)s %(network)s %(action)s %(recipient)s %(subject)s %(message)s
+datefmt = %H:%M:%S
+
 ### HANDLERS ###
 [handlers]
 keys = console
 # use file log instead
 ; keys = logfile
+# add tracim_notification_handler
+; keys = console, tracim_notification
 
 ### Console log ###
 [handler_console]
@@ -498,3 +512,10 @@ level=NOTSET
 # number of max log file = 5
 args=('tracim.log','a',10*1024*1024,5)
 formatter=generic
+
+# file log for tracim_notification
+[handler_tracim_notification]
+class=FileHandler
+level=INFO
+args = ('%(here)s/tracim_notification.log','a')
+formatter=tracim_notification

--- a/backend/tracim_backend/config.py
+++ b/backend/tracim_backend/config.py
@@ -336,10 +336,6 @@ class CFG(object):
         self.EMAIL_NOTIFICATION_SMTP_PASSWORD = settings.get(
             'email.notification.smtp.password',
         )
-        self.EMAIL_NOTIFICATION_LOG_FILE_PATH = settings.get(
-            'email.notification.log_file_path',
-            None,
-        )
 
         self.EMAIL_REPLY_ACTIVATED = asbool(settings.get(
             'email.reply.activated',

--- a/backend/tracim_backend/lib/mail_notifier/notifier.py
+++ b/backend/tracim_backend/lib/mail_notifier/notifier.py
@@ -259,20 +259,28 @@ class EmailManager(object):
             return
 
 
-        logger.info(self, 'Sending asynchronous emails to {} user(s)'.format(len(notifiable_roles)))
+        logger.info(self, 'Generating content {} notification email for {} user(s)'.format(
+            content.content_id,
+            len(notifiable_roles)
+        ))
         # INFO - D.A. - 2014-11-06
         # The following email sender will send emails in the async task queue
         # This allow to build all mails through current thread but really send them (including SMTP connection)
         # In the other thread.
         #
         # This way, the webserver will return sooner (actually before notification emails are sent
-        async_email_sender = EmailSender(
+        email_sender = EmailSender(
             self.config,
             self._smtp_config,
             self.config.EMAIL_NOTIFICATION_ACTIVATED
         )
         for role in notifiable_roles:
-            logger.info(self, 'Sending email to {}'.format(role.user.email))
+            logger.info(self,
+                        'Generating content {} notification email to {}'.format(
+                            content.content_id,
+                            role.user.email
+                        )
+            )
             translator = Translator(app_config=self.config, default_lang=role.user.lang)  # nopep8
             _ = translator.get_translation
             to_addr = formataddr((role.user.display_name, role.user.email))
@@ -351,7 +359,7 @@ class EmailManager(object):
 
             send_email_through(
                 self.config,
-                async_email_sender.send_mail,
+                email_sender.send_mail,
                 message
             )
 

--- a/backend/tracim_backend/lib/mail_notifier/notifier.py
+++ b/backend/tracim_backend/lib/mail_notifier/notifier.py
@@ -188,6 +188,7 @@ class EmailManager(object):
     @staticmethod
     def log_notification(
             config: CFG,
+            msg: str,
             action: str,
             recipient: typing.Optional[str],
             subject: typing.Optional[str],
@@ -201,8 +202,8 @@ class EmailManager(object):
             'network': 'email',
         }
         notification_logger.info(
-            msg='new mail notification',
-            extra=infos
+            msg=msg,
+            extra=infos,
         )
 
     def notify_content_update(
@@ -349,6 +350,7 @@ class EmailManager(object):
             message.attach(part2)
 
             self.log_notification(
+                msg='an email was created to {}'.format(message['To']),
                 action='CREATED',
                 recipient=message['To'],
                 subject=message['Subject'],

--- a/backend/tracim_backend/lib/mail_notifier/notifier.py
+++ b/backend/tracim_backend/lib/mail_notifier/notifier.py
@@ -20,6 +20,7 @@ from tracim_backend.lib.mail_notifier.sender import send_email_through
 from tracim_backend.lib.mail_notifier.utils import EST
 from tracim_backend.lib.mail_notifier.utils import SmtpConfiguration
 from tracim_backend.lib.utils.logger import logger
+from tracim_backend.lib.utils.logger import notification_logger
 from tracim_backend.lib.utils.translation import Translator
 from tracim_backend.lib.utils.utils import get_email_logo_frontend_url
 from tracim_backend.lib.utils.utils import get_login_frontend_url
@@ -192,20 +193,17 @@ class EmailManager(object):
             subject: typing.Optional[str],
     ) -> None:
         """Log notification metadata."""
-        log_path = config.EMAIL_NOTIFICATION_LOG_FILE_PATH
-        if log_path:
-            # TODO - A.P - 2017-09-06 - file logging inefficiency
-            # Updating a document with 100 users to notify will leads to open
-            # and close the file 100 times.
-            with open(log_path, 'a') as log_file:
-                print(
-                    datetime.datetime.now(),
-                    action,
-                    recipient,
-                    subject,
-                    sep='|',
-                    file=log_file,
-                )
+
+        infos = {
+            'action': action,
+            'recipient': recipient,
+            'subject': subject,
+            'network': 'email',
+        }
+        notification_logger.info(
+            msg='new mail notification',
+            extra=infos
+        )
 
     def notify_content_update(
             self,

--- a/backend/tracim_backend/lib/utils/logger.py
+++ b/backend/tracim_backend/lib/utils/logger.py
@@ -55,3 +55,4 @@ class Logger(object):
 
 
 logger = Logger('tracim')
+notification_logger = logging.getLogger('tracim_notification')


### PR DESCRIPTION
related to #1183 

- [X] do not return "async email" when this is not true.
- [X] refactor logger for mail logger, using pastedeploy log instead of custom code.
- [X] more explict log : we are able to know when a synchronous/asynchronous mail is send to EmailSender.