### PR TITLE
Dockerfile "fix"

### DIFF
--- a/tools_docker/Debian_Uwsgi/Dockerfile
+++ b/tools_docker/Debian_Uwsgi/Dockerfile
@@ -102,5 +102,6 @@ RUN \
     && rm -rf /var/lib/apt/list/*
 
 VOLUME ["/etc/tracim", "/var/tracim"]
+EXPOSE 80
 
 CMD ["/bin/bash","/tracim/tools_docker/Debian_Uwsgi/entrypoint.sh"]


### PR DESCRIPTION
Add EXPOSE directive into Dockerfile, so metadata can provide the
listening port

Signed-off-by: Uggla <uggla@free.fr>