### PR TITLE
Rename user.reset_password.validity to .token_validity

### DIFF
--- a/backend/CHANGES.txt
+++ b/backend/CHANGES.txt
@@ -1,15 +1,3 @@
-2.2
----
-
-- (#970) rename 'user.reset_password.validity' to 'user.reset_password.token_validity' in config,
-old parameter is now deprecated.
-
-2.1
----
-
-2.0
----
-
 1.9.1
 ---
 

--- a/backend/CHANGES.txt
+++ b/backend/CHANGES.txt
@@ -1,3 +1,15 @@
+2.2
+---
+
+- (#970) rename 'user.reset_password.validity' to 'user.reset_password.token_validity' in config,
+old parameter is now deprecated.
+
+2.1
+---
+
+2.0
+---
+
 1.9.1
 ---
 

--- a/backend/cypress_test.ini
+++ b/backend/cypress_test.ini
@@ -91,7 +91,7 @@ auth_type = internal
 # User auth token validity in seconds (used to interfaces like web calendars)
 user.auth_token.validity = 604800
 # user reset_password token validity (default to 900s -> 15 minutes)
-user.reset_password.validity = 900
+user.reset_password.token_validity = 900
 
 
 session.type = file

--- a/backend/cypress_test.ini
+++ b/backend/cypress_test.ini
@@ -90,8 +90,8 @@ auth_type = internal
 # ldap_group_enabled = False
 # User auth token validity in seconds (used to interfaces like web calendars)
 user.auth_token.validity = 604800
-# user reset_password token validity (default to 900s -> 15 minutes)
-user.reset_password.token_validity = 900
+# user reset_password token lifetime (default to 900s -> 15 minutes)
+user.reset_password.token_lifetime = 900
 
 
 session.type = file

--- a/backend/development.ini.sample
+++ b/backend/development.ini.sample
@@ -148,7 +148,7 @@ auth_types = internal
 ## User auth token validity in seconds (used to interfaces like web calendars)
 user.auth_token.validity = 604800
 ## user reset_password token validity (default to 900s -> 15 minutes)
-user.reset_password.validity = 900
+user.reset_password.token_validity = 900
 
 ####
 # IHM

--- a/backend/development.ini.sample
+++ b/backend/development.ini.sample
@@ -147,8 +147,8 @@ auth_types = internal
 
 ## User auth token validity in seconds (used to interfaces like web calendars)
 user.auth_token.validity = 604800
-## user reset_password token validity (default to 900s -> 15 minutes)
-user.reset_password.token_validity = 900
+## user reset_password token lifetime (default to 900s -> 15 minutes)
+user.reset_password.token_lifetime = 900
 
 ####
 # IHM

--- a/backend/tests_configs.ini
+++ b/backend/tests_configs.ini
@@ -194,7 +194,7 @@ preview.jpg.restricted_dims = True
 email.notification.activated = false
 website.base_url = http://localhost:6543
 color.config_file_path = %(here)s/color-test.json
-user.reset_password.validity = 5
+user.reset_password.token_validity = 5
 frontend.serve = False
 email.notification.enabled_on_invitation = False
 
@@ -210,7 +210,7 @@ preview.jpg.restricted_dims = True
 email.notification.activated = false
 website.base_url = http://localhost:6543
 color.config_file_path = %(here)s/color-test.json
-user.reset_password.validity = 5
+user.reset_password.token_validity = 5
 frontend.serve = False
 remote_user_header = REMOTE_USER
 
@@ -226,7 +226,7 @@ preview.jpg.restricted_dims = True
 email.notification.activated = false
 website.base_url = http://localhost:6543
 color.config_file_path = %(here)s/color-test.json
-user.reset_password.validity = 5
+user.reset_password.token_validity = 5
 frontend.serve = False
 # webdav
 webdav.root_path = /
@@ -243,7 +243,7 @@ preview.jpg.restricted_dims = True
 email.notification.activated = false
 website.base_url = http://localhost:6543
 color.config_file_path = %(here)s/color-test.json
-user.reset_password.validity = 5
+user.reset_password.token_validity = 5
 frontend.serve = False
 # webdav
 webdav.root_path = /
@@ -261,7 +261,7 @@ preview.jpg.restricted_dims = True
 email.notification.activated = false
 website.base_url = http://localhost:6543
 color.config_file_path = %(here)s/color-test.json
-user.reset_password.validity = 5
+user.reset_password.token_validity = 5
 frontend.serve = False
 
 [functional_test_frontend_enabled]
@@ -276,7 +276,7 @@ preview.jpg.restricted_dims = True
 email.notification.activated = false
 website.base_url = http://localhost:6543
 color.config_file_path = %(here)s/color-test.json
-user.reset_password.validity = 5
+user.reset_password.token_validity = 5
 frontend.serve = True
 
 [functional_test_with_cookie_auth]
@@ -299,7 +299,7 @@ session.cookie_expires = 600
 session.timeout = 600
 session.reissue_time = 120
 session.cookie_on_exception = true
-user.reset_password.validity = 5
+user.reset_password.token_validity = 5
 
 [functional_test_no_db]
 app.enabled = contents/thread,contents/file,contents/html-document,contents/folder
@@ -313,7 +313,7 @@ preview.jpg.restricted_dims = True
 email.notification.activated = false
 website.base_url = http://localhost:6543
 color.config_file_path = %(here)s/color-test.json
-user.reset_password.validity = 5
+user.reset_password.token_validity = 5
 
 [functional_test_with_mail_test_sync]
 app.enabled = contents/thread,contents/file,contents/html-document,contents/folder
@@ -342,7 +342,7 @@ email.notification.smtp.user = test_user
 email.notification.smtp.password = just_a_password
 website.base_url = http://localhost:6543
 color.config_file_path = %(here)s/color-test.json
-user.reset_password.validity = 5
+user.reset_password.token_validity = 5
 email.notification.enabled_on_invitation = False
 
 [functional_test_with_mail_test_sync_with_auto_notif]
@@ -371,7 +371,7 @@ email.notification.smtp.user = test_user
 email.notification.smtp.password = just_a_password
 website.base_url = http://localhost:6543
 color.config_file_path = %(here)s/color-test.json
-user.reset_password.validity = 5
+user.reset_password.token_validity = 5
 email.notification.enabled_on_invitation = True
 
 [functional_test_with_mail_test_sync_ldap_auth_only]
@@ -400,7 +400,7 @@ email.notification.smtp.user = test_user
 email.notification.smtp.password = just_a_password
 website.base_url = http://localhost:6543
 color.config_file_path = %(here)s/color-test.json
-user.reset_password.validity = 5
+user.reset_password.token_validity = 5
 auth_types=ldap
 ldap_url = ldap://localhost:3890
 ldap_base_dn = dc=planetexpress,dc=com
@@ -421,7 +421,7 @@ preview_cache_dir = /tmp/test/preview_cache
 preview.jpg.restricted_dims = True
 website.base_url = http://localhost:6543
 color.config_file_path = %(here)s/color-test.json
-user.reset_password.validity = 5
+user.reset_password.token_validity = 5
 auth_types=internal
 # important param
 email.notification.activated = False
@@ -437,7 +437,7 @@ preview_cache_dir = /tmp/test/preview_cache
 preview.jpg.restricted_dims = True
 website.base_url = http://localhost:6543
 color.config_file_path = %(here)s/color-test.json
-user.reset_password.validity = 5
+user.reset_password.token_validity = 5
 auth_types=internal
 # important param
 email.notification.activated = False
@@ -453,7 +453,7 @@ preview_cache_dir = /tmp/test/preview_cache
 preview.jpg.restricted_dims = True
 website.base_url = http://localhost:6543
 color.config_file_path = %(here)s/color-test.json
-user.reset_password.validity = 5
+user.reset_password.token_validity = 5
 auth_types=internal
 # important param
 email.notification.activated = True
@@ -489,7 +489,7 @@ email.notification.smtp.user = test_user
 email.notification.smtp.password = just_a_password
 website.base_url = http://localhost:6543
 color.config_file_path = %(here)s/color-test.json
-user.reset_password.validity = 5
+user.reset_password.token_validity = 5
 
 [webdav_test]
 app.enabled = contents/thread,contents/file,contents/html-document,contents/folder

--- a/backend/tests_configs.ini
+++ b/backend/tests_configs.ini
@@ -194,7 +194,7 @@ preview.jpg.restricted_dims = True
 email.notification.activated = false
 website.base_url = http://localhost:6543
 color.config_file_path = %(here)s/color-test.json
-user.reset_password.token_validity = 5
+user.reset_password.token_lifetime = 5
 frontend.serve = False
 email.notification.enabled_on_invitation = False
 
@@ -210,7 +210,7 @@ preview.jpg.restricted_dims = True
 email.notification.activated = false
 website.base_url = http://localhost:6543
 color.config_file_path = %(here)s/color-test.json
-user.reset_password.token_validity = 5
+user.reset_password.token_lifetime = 5
 frontend.serve = False
 remote_user_header = REMOTE_USER
 
@@ -226,7 +226,7 @@ preview.jpg.restricted_dims = True
 email.notification.activated = false
 website.base_url = http://localhost:6543
 color.config_file_path = %(here)s/color-test.json
-user.reset_password.token_validity = 5
+user.reset_password.token_lifetime = 5
 frontend.serve = False
 # webdav
 webdav.root_path = /
@@ -243,7 +243,7 @@ preview.jpg.restricted_dims = True
 email.notification.activated = false
 website.base_url = http://localhost:6543
 color.config_file_path = %(here)s/color-test.json
-user.reset_password.token_validity = 5
+user.reset_password.token_lifetime = 5
 frontend.serve = False
 # webdav
 webdav.root_path = /
@@ -261,7 +261,7 @@ preview.jpg.restricted_dims = True
 email.notification.activated = false
 website.base_url = http://localhost:6543
 color.config_file_path = %(here)s/color-test.json
-user.reset_password.token_validity = 5
+user.reset_password.token_lifetime = 5
 frontend.serve = False
 
 [functional_test_frontend_enabled]
@@ -276,7 +276,7 @@ preview.jpg.restricted_dims = True
 email.notification.activated = false
 website.base_url = http://localhost:6543
 color.config_file_path = %(here)s/color-test.json
-user.reset_password.token_validity = 5
+user.reset_password.token_lifetime = 5
 frontend.serve = True
 
 [functional_test_with_cookie_auth]
@@ -299,7 +299,7 @@ session.cookie_expires = 600
 session.timeout = 600
 session.reissue_time = 120
 session.cookie_on_exception = true
-user.reset_password.token_validity = 5
+user.reset_password.token_lifetime = 5
 
 [functional_test_no_db]
 app.enabled = contents/thread,contents/file,contents/html-document,contents/folder
@@ -313,7 +313,7 @@ preview.jpg.restricted_dims = True
 email.notification.activated = false
 website.base_url = http://localhost:6543
 color.config_file_path = %(here)s/color-test.json
-user.reset_password.token_validity = 5
+user.reset_password.token_lifetime = 5
 
 [functional_test_with_mail_test_sync]
 app.enabled = contents/thread,contents/file,contents/html-document,contents/folder
@@ -342,7 +342,7 @@ email.notification.smtp.user = test_user
 email.notification.smtp.password = just_a_password
 website.base_url = http://localhost:6543
 color.config_file_path = %(here)s/color-test.json
-user.reset_password.token_validity = 5
+user.reset_password.token_lifetime = 5
 email.notification.enabled_on_invitation = False
 
 [functional_test_with_mail_test_sync_with_auto_notif]
@@ -371,7 +371,7 @@ email.notification.smtp.user = test_user
 email.notification.smtp.password = just_a_password
 website.base_url = http://localhost:6543
 color.config_file_path = %(here)s/color-test.json
-user.reset_password.token_validity = 5
+user.reset_password.token_lifetime = 5
 email.notification.enabled_on_invitation = True
 
 [functional_test_with_mail_test_sync_ldap_auth_only]
@@ -400,7 +400,7 @@ email.notification.smtp.user = test_user
 email.notification.smtp.password = just_a_password
 website.base_url = http://localhost:6543
 color.config_file_path = %(here)s/color-test.json
-user.reset_password.token_validity = 5
+user.reset_password.token_lifetime = 5
 auth_types=ldap
 ldap_url = ldap://localhost:3890
 ldap_base_dn = dc=planetexpress,dc=com
@@ -421,7 +421,7 @@ preview_cache_dir = /tmp/test/preview_cache
 preview.jpg.restricted_dims = True
 website.base_url = http://localhost:6543
 color.config_file_path = %(here)s/color-test.json
-user.reset_password.token_validity = 5
+user.reset_password.token_lifetime = 5
 auth_types=internal
 # important param
 email.notification.activated = False
@@ -437,7 +437,7 @@ preview_cache_dir = /tmp/test/preview_cache
 preview.jpg.restricted_dims = True
 website.base_url = http://localhost:6543
 color.config_file_path = %(here)s/color-test.json
-user.reset_password.token_validity = 5
+user.reset_password.token_lifetime = 5
 auth_types=internal
 # important param
 email.notification.activated = False
@@ -453,7 +453,7 @@ preview_cache_dir = /tmp/test/preview_cache
 preview.jpg.restricted_dims = True
 website.base_url = http://localhost:6543
 color.config_file_path = %(here)s/color-test.json
-user.reset_password.token_validity = 5
+user.reset_password.token_lifetime = 5
 auth_types=internal
 # important param
 email.notification.activated = True
@@ -489,7 +489,7 @@ email.notification.smtp.user = test_user
 email.notification.smtp.password = just_a_password
 website.base_url = http://localhost:6543
 color.config_file_path = %(here)s/color-test.json
-user.reset_password.token_validity = 5
+user.reset_password.token_lifetime = 5
 
 [webdav_test]
 app.enabled = contents/thread,contents/file,contents/html-document,contents/folder

--- a/backend/tracim_backend/config.py
+++ b/backend/tracim_backend/config.py
@@ -228,7 +228,7 @@ class CFG(object):
             '604800',
         ))
         self.USER_RESET_PASSWORD_TOKEN_VALIDITY = int(settings.get(
-            'user.reset_password.validity',
+            'user.reset_password.token_validity',
             '900'
         ))
 

--- a/backend/tracim_backend/config.py
+++ b/backend/tracim_backend/config.py
@@ -227,10 +227,24 @@ class CFG(object):
             'user.auth_token.validity',
             '604800',
         ))
-        self.USER_RESET_PASSWORD_TOKEN_VALIDITY = int(settings.get(
+
+        # TODO - G.M - 2019-03-14 - retrocompat code,
+        # will be deleted in the future
+        legacy_reset_password_validity = settings.get('user.reset_password.validity', None)
+        if legacy_reset_password_validity:
+            logger.warning(
+                self,
+                'user.reset_password.validity parameter is deprecated ! '
+                'please use user.reset_password.token_validity instead.'
+            )
+        reset_password_validity = settings.get(
             'user.reset_password.token_validity',
-            '900'
-        ))
+            None
+        )
+        defaut_reset_password_validity = '900'
+        self.USER_RESET_PASSWORD_TOKEN_VALIDITY = reset_password_validity or \
+                                                  legacy_reset_password_validity or \
+                                                  defaut_reset_password_validity
 
         self.DEBUG = asbool(settings.get('debug', False))
         # TODO - G.M - 27-03-2018 - [Email] Restore email config

--- a/backend/tracim_backend/config.py
+++ b/backend/tracim_backend/config.py
@@ -235,16 +235,16 @@ class CFG(object):
             logger.warning(
                 self,
                 'user.reset_password.validity parameter is deprecated ! '
-                'please use user.reset_password.token_validity instead.'
+                'please use user.reset_password.token_lifetime instead.'
             )
-        reset_password_validity = settings.get(
-            'user.reset_password.token_validity',
+        reset_password_token_lifetime = settings.get(
+            'user.reset_password.token_lifetime',
             None
         )
         defaut_reset_password_validity = '900'
-        self.USER_RESET_PASSWORD_TOKEN_VALIDITY = int(reset_password_validity or \
-                                                  legacy_reset_password_validity or \
-                                                  defaut_reset_password_validity)
+        self.USER_RESET_PASSWORD_TOKEN_LIFETIME = int(reset_password_token_lifetime or \
+                                                      legacy_reset_password_validity or \
+                                                      defaut_reset_password_validity)
 
         self.DEBUG = asbool(settings.get('debug', False))
         # TODO - G.M - 27-03-2018 - [Email] Restore email config

--- a/backend/tracim_backend/config.py
+++ b/backend/tracim_backend/config.py
@@ -242,9 +242,9 @@ class CFG(object):
             None
         )
         defaut_reset_password_validity = '900'
-        self.USER_RESET_PASSWORD_TOKEN_VALIDITY = reset_password_validity or \
+        self.USER_RESET_PASSWORD_TOKEN_VALIDITY = int(reset_password_validity or \
                                                   legacy_reset_password_validity or \
-                                                  defaut_reset_password_validity
+                                                  defaut_reset_password_validity)
 
         self.DEBUG = asbool(settings.get('debug', False))
         # TODO - G.M - 27-03-2018 - [Email] Restore email config

--- a/backend/tracim_backend/config.py
+++ b/backend/tracim_backend/config.py
@@ -229,7 +229,7 @@ class CFG(object):
         ))
 
         # TODO - G.M - 2019-03-14 - retrocompat code,
-        # will be deleted in the future
+        # will be deleted in the future (https://github.com/tracim/tracim/issues/1483)
         legacy_reset_password_validity = settings.get('user.reset_password.validity', None)
         if legacy_reset_password_validity:
             logger.warning(

--- a/backend/tracim_backend/lib/core/user.py
+++ b/backend/tracim_backend/lib/core/user.py
@@ -868,7 +868,7 @@ class UserApi(object):
         self._check_password_modification_allowed(user)
         return user.validate_reset_password_token(
             token=token,
-            validity_seconds=self._config.USER_RESET_PASSWORD_TOKEN_VALIDITY,
+            validity_seconds=self._config.USER_RESET_PASSWORD_TOKEN_LIFETIME,
         )
 
     def enable(self, user: User, do_save=False):

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,11 @@
 
 - If user does not manually change the language, email notifications will stay in English. In order to get notifications in French, change language to English, then back to French (issue #1374)
 
+### Others Changes
+
+- rename 'user.reset_password.validity' to 'user.reset_password.token_validity' in config,
+old parameter is now deprecated. (issue #970)
+
 
 ## 2.1.0 / 2019-02-15
 

--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,7 @@
 
 ### Others Changes
 
-- rename 'user.reset_password.validity' to 'user.reset_password.token_validity' in config,
+- rename 'user.reset_password.validity' to 'user.reset_password.token_lifetime' in config,
 old parameter is now deprecated. (issue #970)
 
 


### PR DESCRIPTION
related to [tracim/tracim#970](https://github.com/tracim/tracim/issues/970)
to do:

- [X]  rename `user.reset_password.validity` to `user.reset_password.token_validity`.
- [X]  support for legacy config file .
- [X]  update changelog about this change.