### PR TITLE
[#1226] fix wrong parameter for reply by email [ci skip]

### DIFF
--- a/tools_docker/Debian_Uwsgi/common.sh
+++ b/tools_docker/Debian_Uwsgi/common.sh
@@ -15,7 +15,7 @@ if [ ! -f /etc/tracim/development.ini ]; then
     sed -i "s|basic_setup.api_key =.*|basic_setup.api_key = $KEY|g" /etc/tracim/development.ini
     sed -i "s|basic_setup.session_secret = change_this_value_please\!|basic_setup.session_secret = $SECRET|g" /etc/tracim/development.ini
     sed -i "s|email.template_dir = .*|email.template_dir = /tracim/backend/tracim_backend/templates/mail|g" /etc/tracim/development.ini
-    sed -i "s|email.reply.lockfile_path = .*|email.reply.lockfile_path = /var/tracim/data|g" /etc/tracim/development.ini
+    sed -i "s|email.reply.lockfile_path = .*|email.reply.lockfile_path = /var/tracim/data/email_fetcher.lock|g" /etc/tracim/development.ini
     sed -i "s|webdav.listen = .*|webdav.listen = 127.0.0.1:3030|g" /etc/tracim/development.ini
     sed -i "s|;webdav.root_path = /|webdav.root_path = /webdav|g" /etc/tracim/development.ini
     sed -i "s|; wsgidav.client.base_url = .*|wsgidav.client.base_url = 127.0.0.1:3030|g" /etc/tracim/development.ini


### PR DESCRIPTION
- [x] fix wrong parameter in common.sh for change in development.ini when you start new container whis new volume. 

If you have used volume before, development.ini file is not changed (you need to change this parameter manually).