### PR TITLE
front - adds new commands to format tags in cypress

### DIFF
--- a/functionnal_tests/cypress/support/generic_selector_commands.js
+++ b/functionnal_tests/cypress/support/generic_selector_commands.js
@@ -6,9 +6,9 @@ const SELECTORS = {
 
 
 const TAGS = {
-  contentFrame: () => '[data-cy="popinFixed"]',
-  contentInList: () => `.workspace__content__fileandfolder > .content`,
-  workspaceMenu: ({workspaceId}) => `[data-cy=sidebar__content__navigation__workspace__item_${workspaceId}]`
+  [SELECTORS.CONTENT_FRAME]: () => '[data-cy="popinFixed"]',
+  [SELECTORS.CONTENT_IN_LIST]: () => `.workspace__content__fileandfolder > .content`,
+  [SELECTORS.WORKSPACE_MENU]: ({workspaceId}) => `[data-cy=sidebar__content__navigation__workspace__item_${workspaceId}]`
 }
 
 /** 

--- a/functionnal_tests/cypress/support/generic_selector_commands.js
+++ b/functionnal_tests/cypress/support/generic_selector_commands.js
@@ -4,31 +4,30 @@ const SELECTORS = {
   WORKSPACE_MENU: 'workspaceMenu'
 }
 
-
 const TAGS = {
   [SELECTORS.CONTENT_FRAME]: () => '[data-cy="popinFixed"]',
   [SELECTORS.CONTENT_IN_LIST]: () => `.workspace__content__fileandfolder > .content`,
-  [SELECTORS.WORKSPACE_MENU]: ({workspaceId}) => `[data-cy=sidebar__content__navigation__workspace__item_${workspaceId}]`
+  [SELECTORS.WORKSPACE_MENU]: ({ workspaceId }) => `[data-cy=sidebar__content__navigation__workspace__item_${workspaceId}]`
 }
 
-/** 
+/**
   * Generate a lazy html tag.
   * @param {selectorName} selectorName: key of the tag mapped in TAGS.
  */
 const reverseTag = (selectorName) => {
-  if (! (selectorName in TAGS)) {
+  if (!(selectorName in TAGS)) {
     throw `No selector found for selector name ${selectorName}`
   }
   return TAGS[selectorName]
 }
 
-/** 
+/**
   * Format a url for a given pageName mapped in URLS and applies getters at the end.
   * @param {string} selectorName: key of the tag mapped in TAGS.
   * @param {Object} param: object containing the key/value to use on the lazy tag.
-  * @param {Object} attrs: object containing the key/value to format html attrs selector. 
+  * @param {Object} attrs: object containing the key/value to format html attrs selector.
  */
-const formatTag = ({selectorName, params = {}, attrs = null}) => {
+const formatTag = ({ selectorName, params = {}, attrs = null }) => {
   let tag = reverseTag(selectorName)(params)
   if (attrs) {
     Object.entries(attrs).forEach(([key, value]) => tag += `[${key}="${value}"]`)
@@ -36,8 +35,8 @@ const formatTag = ({selectorName, params = {}, attrs = null}) => {
   return tag
 }
 
-Cypress.Commands.add('getTag', ({selectorName, params = {}, attrs = null}) => {
-  return cy.get(formatTag({selectorName: selectorName, params: params, attrs: attrs}))
+Cypress.Commands.add('getTag', ({ selectorName, params = {}, attrs = null }) => {
+  return cy.get(formatTag({ selectorName: selectorName, params: params, attrs: attrs }))
 })
 
 export { SELECTORS, formatTag, reverseTag }

--- a/functionnal_tests/cypress/support/generic_selector_commands.js
+++ b/functionnal_tests/cypress/support/generic_selector_commands.js
@@ -1,0 +1,43 @@
+const SELECTORS = {
+  CONTENT_FRAME: 'contentFrame',
+  CONTENT_IN_LIST: 'contentInList',
+  WORKSPACE_MENU: 'workspaceMenu'
+}
+
+
+const TAGS = {
+  contentFrame: () => '[data-cy="popinFixed"]',
+  contentInList: () => `.workspace__content__fileandfolder > .content`,
+  workspaceMenu: ({workspaceId}) => `[data-cy=sidebar__content__navigation__workspace__item_${workspaceId}]`
+}
+
+/** 
+  * Generate a lazy html tag.
+  * @param {selectorName} selectorName: key of the tag mapped in TAGS.
+ */
+const reverseTag = (selectorName) => {
+  if (! (selectorName in TAGS)) {
+    throw `No selector found for selector name ${selectorName}`
+  }
+  return TAGS[selectorName]
+}
+
+/** 
+  * Format a url for a given pageName mapped in URLS and applies getters at the end.
+  * @param {string} selectorName: key of the tag mapped in TAGS.
+  * @param {Object} param: object containing the key/value to use on the lazy tag.
+  * @param {Object} attrs: object containing the key/value to format html attrs selector. 
+ */
+const formatTag = ({selectorName, params = {}, attrs = null}) => {
+  let tag = reverseTag(selectorName)(params)
+  if (attrs) {
+    Object.entries(attrs).forEach(([key, value]) => tag += `[${key}="${value}"]`)
+  }
+  return tag
+}
+
+Cypress.Commands.add('getTag', ({selectorName, params = {}, attrs = null}) => {
+  return cy.get(formatTag({selectorName: selectorName, params: params, attrs: attrs}))
+})
+
+export { SELECTORS, formatTag, reverseTag }


### PR DESCRIPTION
#1826 adds 2 new function to format tags and a new cypress command to use instead of the usual `cy.get`

- [x] Code is clear enough
