### PR TITLE
Fix/1900 streaming upload for webdav

### DIFF
--- a/backend/tracim_backend/lib/webdav/resources.py
+++ b/backend/tracim_backend/lib/webdav/resources.py
@@ -960,6 +960,8 @@ class OtherFileResource(FileResource):
 
     @webdav_check_right(is_reader)
     def getContent(self):
+        # TODO - G.M - 2019-06-13 - find solution to handle properly big file here without having
+        # big file in memory. see https://github.com/tracim/tracim/issues/1913
         filestream = compat.BytesIO()
 
         filestream.write(bytes(self.content_designed, "utf-8"))
@@ -971,6 +973,8 @@ class OtherFileResource(FileResource):
         return {"type": self.content.type.capitalize()}
 
     def design(self):
+        # TODO - G.M - 2019-06-13 - find solution to handle properly big file here without having
+        # big file in memory. see https://github.com/tracim/tracim/issues/1913
         if content_type_list.get_one_by_slug(self.content.type) == content_type_list.Page:
             return design_page(self.content, self.content_revision)
         if content_type_list.get_one_by_slug(self.content.type) == content_type_list.Thread:

--- a/backend/tracim_backend/lib/webdav/resources.py
+++ b/backend/tracim_backend/lib/webdav/resources.py
@@ -703,11 +703,7 @@ class FileResource(DAVNonCollection):
 
     @webdav_check_right(is_reader)
     def getContent(self) -> typing.BinaryIO:
-        filestream = compat.BytesIO()
-        filestream.write(self.content.depot_file.file.read())
-        filestream.seek(0)
-
-        return filestream
+        return self.content.depot_file.file
 
     def beginWrite(self, contentType: str = None) -> FakeFileStream:
         return FakeFileStream(

--- a/backend/tracim_backend/lib/webdav/utils.py
+++ b/backend/tracim_backend/lib/webdav/utils.py
@@ -63,6 +63,10 @@ class FakeFileStream(object):
         :param content:
         :param parent:
         """
+        # TODO - G.M - 2019-06-13 - use true streaming mecanism,
+        # instead of a true streaming mecanism we use
+        # a temporary file to avoid big file in memory without needing to refactor all
+        # upload mecanism of webdav
         self.temp_file = tempfile.NamedTemporaryFile(suffix="tracim_webdav_upload_")
         self._session = session
         self._file_name = file_name if file_name != "" else self._content.file_name

--- a/backend/tracim_backend/lib/webdav/utils.py
+++ b/backend/tracim_backend/lib/webdav/utils.py
@@ -67,6 +67,7 @@ class FakeFileStream(object):
         # instead of a true streaming mecanism we use
         # a temporary file to avoid big file in memory without needing to refactor all
         # upload mecanism of webdav
+        # see https://github.com/tracim/tracim/issues/1911
         self.temp_file = tempfile.NamedTemporaryFile(suffix="tracim_webdav_upload_")
         self._session = session
         self._file_name = file_name if file_name != "" else self._content.file_name

--- a/backend/tracim_backend/lib/webdav/utils.py
+++ b/backend/tracim_backend/lib/webdav/utils.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
+import tempfile
 
 from sqlalchemy.orm import Session
 import transaction
-from wsgidav import compat
 from wsgidav import util
 from wsgidav.dav_error import HTTP_FORBIDDEN
 from wsgidav.dav_error import DAVError
@@ -63,7 +63,7 @@ class FakeFileStream(object):
         :param content:
         :param parent:
         """
-        self._file_stream = compat.BytesIO()
+        self.temp_file = tempfile.NamedTemporaryFile(suffix="tracim_webdav_upload_")
         self._session = session
         self._file_name = file_name if file_name != "" else self._content.file_name
         self._content = content
@@ -98,7 +98,7 @@ class FakeFileStream(object):
         """
         Called by request_server when writing content to files, we put it inside a filestream
         """
-        self._file_stream.write(s)
+        self.temp_file.write(s)
 
     def close(self):
         """
@@ -106,7 +106,7 @@ class FakeFileStream(object):
         a new revision
         """
 
-        self._file_stream.seek(0)
+        self.temp_file.seek(0)
 
         if self._content is None:
             self.create_file()
@@ -114,6 +114,7 @@ class FakeFileStream(object):
             self.update_file()
 
         transaction.commit()
+        self.temp_file.close()
 
     def create_file(self):
         """
@@ -132,10 +133,7 @@ class FakeFileStream(object):
                     do_save=False,
                 )
                 self._api.update_file_data(
-                    file,
-                    self._file_name,
-                    util.guessMimeType(self._file_name),
-                    self._file_stream.read(),
+                    file, self._file_name, util.guessMimeType(self._file_name), self.temp_file
                 )
                 self._api.execute_created_content_actions(file)
         except TracimException as exc:
@@ -152,7 +150,7 @@ class FakeFileStream(object):
                     self._content,
                     self._file_name,
                     util.guessMimeType(self._content.file_name),
-                    self._file_stream.read(),
+                    self.temp_file,
                 )
         except TracimException as exc:
             raise DAVError(HTTP_FORBIDDEN) from exc


### PR DESCRIPTION
related to #1900.
This does:
- webdav upload using a temporary file instead of in memory
- webdav download of file object does not read whole file in memory before sending.

This does not fix:
- use true streaming mecanism (use temporary fix instead) see #1911 
- fix memory issue when downloading big non-file content (html-document, threads) see #1913 

## Checkpoints

The goal of this section is to help code reviewer to do required checks on this pull request. Please don't edit this list.
If one or more of these checkpoints are out of scope, please write below why they are.

- [x] Code is clear enoug
- [x] If there are FIXME in the code, then there are associated issues and issue is referenced in the FIXME
- [x] If there are TODO, NOTE or HACK in code, date and developer initials are present
- [x] Automated tests have been written (covering feature or non regression), or *at least* an issue has been created for test implementation
