### PR TITLE
Fix/1553 message for empty comments

### DIFF
--- a/frontend_app_file/i18next.scanner/en/translation.json
+++ b/frontend_app_file/i18next.scanner/en/translation.json
@@ -49,5 +49,6 @@
   "files": "files",
   "This content is deprecated": "This content is deprecated",
   "Previous page": "Previous page",
-  "Next page": "Next page"
+  "Next page": "Next page",
+  "You can't send an empty comment": "You can't send an empty comment"
 }

--- a/frontend_app_file/i18next.scanner/fr/translation.json
+++ b/frontend_app_file/i18next.scanner/fr/translation.json
@@ -49,5 +49,6 @@
   "files": "fichiers",
   "This content is deprecated": "Ce contenu est obsolète",
   "Previous page": "Page précédente",
-  "Next page": "Page suivante"
+  "Next page": "Page suivante",
+  "You can't send an empty comment": "Vous ne pouvez pas envoyer un commentaire vide"
 }

--- a/frontend_app_file/src/container/File.jsx
+++ b/frontend_app_file/src/container/File.jsx
@@ -360,6 +360,13 @@ class File extends React.Component {
         this.loadContent()
         this.loadTimeline()
         break
+      case 400:
+        switch (fetchResultSaveNewComment.apiResponse.body.code) {
+          case 2003:
+            this.sendGlobalFlashMessage(props.t('You can\'t send an empty comment')); break
+          default: this.sendGlobalFlashMessage(props.t('Error while saving new comment')); break
+        }
+        break
       default: this.sendGlobalFlashMessage(props.t('Error while saving new comment')); break
     }
   }

--- a/frontend_app_file/src/container/File.jsx
+++ b/frontend_app_file/src/container/File.jsx
@@ -363,8 +363,11 @@ class File extends React.Component {
       case 400:
         switch (fetchResultSaveNewComment.apiResponse.body.code) {
           case 2003:
-            this.sendGlobalFlashMessage(props.t('You can\'t send an empty comment')); break
-          default: this.sendGlobalFlashMessage(props.t('Error while saving new comment')); break
+            this.sendGlobalFlashMessage(props.t("You can't send an empty comment"));
+            break
+          default:
+            this.sendGlobalFlashMessage(props.t('Error while saving new comment'));
+            break
         }
         break
       default: this.sendGlobalFlashMessage(props.t('Error while saving new comment')); break

--- a/frontend_app_html-document/i18next.scanner/en/translation.json
+++ b/frontend_app_html-document/i18next.scanner/en/translation.json
@@ -26,5 +26,6 @@
   "Text document": "Text document",
   "text document": "text document",
   "text documents": "text documents",
-  "This content is deprecated": "This content is deprecated"
+  "This content is deprecated": "This content is deprecated",
+  "You can't send an empty comment": "You can't send an empty comment"
 }

--- a/frontend_app_html-document/i18next.scanner/fr/translation.json
+++ b/frontend_app_html-document/i18next.scanner/fr/translation.json
@@ -26,5 +26,6 @@
   "Text document": "Document texte",
   "text document": "document texte",
   "text documents": "documents texte",
-  "This content is deprecated": "Ce contenu est obsolète"
+  "This content is deprecated": "Ce contenu est obsolète",
+  "You can't send an empty comment": "Vous ne pouvez pas envoyer un commentaire vide"
 }

--- a/frontend_app_html-document/src/container/HtmlDocument.jsx
+++ b/frontend_app_html-document/src/container/HtmlDocument.jsx
@@ -412,8 +412,11 @@ class HtmlDocument extends React.Component {
       case 400:
         switch (fetchResultSaveNewComment.apiResponse.body.code) {
           case 2003:
-            this.sendGlobalFlashMessage(props.t('You can\'t send an empty comment')); break
-          default: this.sendGlobalFlashMessage(props.t('Error while saving new comment')); break
+            this.sendGlobalFlashMessage(props.t("You can't send an empty comment"));
+            break
+          default:
+            this.sendGlobalFlashMessage(props.t('Error while saving new comment'));
+            break
         }
         break
       default: this.sendGlobalFlashMessage(props.t('Error while saving new comment')); break

--- a/frontend_app_html-document/src/container/HtmlDocument.jsx
+++ b/frontend_app_html-document/src/container/HtmlDocument.jsx
@@ -409,6 +409,13 @@ class HtmlDocument extends React.Component {
         if (state.timelineWysiwyg) tinymce.get('wysiwygTimelineComment').setContent('')
         this.loadContent()
         break
+      case 400:
+        switch (fetchResultSaveNewComment.apiResponse.body.code) {
+          case 2003:
+            this.sendGlobalFlashMessage(props.t('You can\'t send an empty comment')); break
+          default: this.sendGlobalFlashMessage(props.t('Error while saving new comment')); break
+        }
+        break
       default: this.sendGlobalFlashMessage(props.t('Error while saving new comment')); break
     }
   }

--- a/frontend_app_thread/i18next.scanner/en/translation.json
+++ b/frontend_app_thread/i18next.scanner/en/translation.json
@@ -15,5 +15,6 @@
   "Error while changing status": "Error while changing status",
   "Thread": "Thread",
   "thread": "thread",
-  "threads": "threads"
+  "threads": "threads",
+  "You can't send an empty comment": "You can't send an empty comment"
 }

--- a/frontend_app_thread/i18next.scanner/fr/translation.json
+++ b/frontend_app_thread/i18next.scanner/fr/translation.json
@@ -15,5 +15,6 @@
   "Error while changing status": "Erreur lors de la sauvegarde du statut",
   "Thread": "Discussion",
   "thread": "discussion",
-  "threads": "discussions"
+  "threads": "discussions",
+  "You can't send an empty comment": "Vous ne pouvez pas envoyer un commentaire vide"
 }

--- a/frontend_app_thread/src/container/Thread.jsx
+++ b/frontend_app_thread/src/container/Thread.jsx
@@ -292,11 +292,11 @@ class Thread extends React.Component {
       case 400:
         switch (fetchResultSaveNewComment.body.code) {
           case 2003:
-            console.log('here')
             this.sendGlobalFlashMessage(props.t('You can\'t send an empty comment')); break
+          default: this.sendGlobalFlashMessage(props.t('Error while saving new comment')); break
         }
         break
-      default: console.log('or here'); this.sendGlobalFlashMessage(props.t('Error while saving new comment')); break
+      default: this.sendGlobalFlashMessage(props.t('Error while saving new comment')); break
     }
   }
 

--- a/frontend_app_thread/src/container/Thread.jsx
+++ b/frontend_app_thread/src/container/Thread.jsx
@@ -289,7 +289,14 @@ class Thread extends React.Component {
         if (state.timelineWysiwyg) tinymce.get('wysiwygTimelineComment').setContent('')
         this.loadContent()
         break
-      default: this.sendGlobalFlashMessage(props.t('Error while saving new comment')); break
+      case 400:
+        switch (fetchResultSaveNewComment.body.code) {
+          case 2003:
+            console.log('here')
+            this.sendGlobalFlashMessage(props.t('You can\'t send an empty comment')); break
+        }
+        break
+      default: console.log('or here'); this.sendGlobalFlashMessage(props.t('Error while saving new comment')); break
     }
   }
 

--- a/frontend_app_thread/src/container/Thread.jsx
+++ b/frontend_app_thread/src/container/Thread.jsx
@@ -292,8 +292,11 @@ class Thread extends React.Component {
       case 400:
         switch (fetchResultSaveNewComment.body.code) {
           case 2003:
-            this.sendGlobalFlashMessage(props.t('You can\'t send an empty comment')); break
-          default: this.sendGlobalFlashMessage(props.t('Error while saving new comment')); break
+            this.sendGlobalFlashMessage(props.t("You can't send an empty comment"));
+            break
+          default:
+            this.sendGlobalFlashMessage(props.t('Error while saving new comment'));
+            break
         }
         break
       default: this.sendGlobalFlashMessage(props.t('Error while saving new comment')); break


### PR DESCRIPTION
Adds a clear message when posting an empty comment.

## Checkpoints

- [x] Code is clear enough
