### PR TITLE
[for 2.6.0] Fix hidden sidebar arrow on ios

### DIFF
--- a/frontend/src/css/Sidebar.styl
+++ b/frontend/src/css/Sidebar.styl
@@ -15,6 +15,9 @@ sidebarColorDarken = darken(sidebarColor, 15%)
   justify-content space-between
   height 100%
 
+.sidebarpagecontainer
+  -webkit-transform translateZ(0)
+
 .sidebar
   position relative
   transition all sidebar-animate-speed

--- a/frontend/src/css/Sidebar.styl
+++ b/frontend/src/css/Sidebar.styl
@@ -15,6 +15,8 @@ sidebarColorDarken = darken(sidebarColor, 15%)
   justify-content space-between
   height 100%
 
+// INFO - GM - 2019-12-31 - Workaround in order to fix the sidebar arrow which become hidden only on IOS,
+// workaround found here https://stackoverflow.com/questions/29482203/iphone-fixed-position-div-invisible
 .sidebarpagecontainer
   -webkit-transform translateZ(0)
 


### PR DESCRIPTION
#1891 

This issues seems to be related to the parent div which has `overflow: hidden` and the sidebar arrow has `position: fixed`, the sidebar arrow become hidden only on IOS.
This workaround have been found [here](https://stackoverflow.com/questions/29482203/iphone-fixed-position-div-invisible)

## Checkpoints

The goal of this section is to help code reviewer to do required checks on this pull request. Please don't edit this list.
If one or more of these checkpoints are out of scope, please write below why they are.

- [x] Code is clear enough
- [x] If there are FIXME in the code, then there are associated issues and issue is referenced in the FIXME
- [x] If there are TODO, NOTE or HACK in code, date and developer initials are present
- [x] Automated tests have been written (covering feature or non regression), or *at least* an issue has been created for test implementation
