### PR TITLE
[For 2.6.3] fix(backend): add smtp implicit encryption support

### DIFF
--- a/backend/development.ini.sample
+++ b/backend/development.ini.sample
@@ -317,6 +317,10 @@ email.notification.smtp.server = your_smtp_server
 email.notification.smtp.port = 25
 email.notification.smtp.user = your_smtp_user
 email.notification.smtp.password = your_smtp_password
+## active implicit ssl if you are using implicit smtp with encryption port like 465
+## by default, tracim will try to use explicit smtp encryption using starttls, and unencrypted
+## connection as fallback.
+email.notification.smtp.implicit_ssl = false
 
 ### Headers ###
 email.notification.from.default_label = Tracim Notifications

--- a/backend/development.ini.sample
+++ b/backend/development.ini.sample
@@ -317,9 +317,9 @@ email.notification.smtp.server = your_smtp_server
 email.notification.smtp.port = 25
 email.notification.smtp.user = your_smtp_user
 email.notification.smtp.password = your_smtp_password
-## active implicit ssl if you are using implicit smtp with encryption port like 465
-## by default, tracim will try to use explicit smtp encryption using starttls, and unencrypted
-## connection as fallback.
+# active implicit ssl if you are using implicit smtp with encryption port like 465
+# by default, tracim will try to use explicit smtp encryption using starttls, and unencrypted
+# connection as fallback.
 email.notification.smtp.use_implicit_ssl = false
 
 ### Headers ###

--- a/backend/development.ini.sample
+++ b/backend/development.ini.sample
@@ -320,7 +320,7 @@ email.notification.smtp.password = your_smtp_password
 ## active implicit ssl if you are using implicit smtp with encryption port like 465
 ## by default, tracim will try to use explicit smtp encryption using starttls, and unencrypted
 ## connection as fallback.
-email.notification.smtp.implicit_ssl = false
+email.notification.smtp.use_implicit_ssl = false
 
 ### Headers ###
 email.notification.from.default_label = Tracim Notifications

--- a/backend/doc/setting.md
+++ b/backend/doc/setting.md
@@ -311,7 +311,7 @@ to enable mail notification, smallest config is this:
     ## active implicit ssl if you are using implicit smtp with encryption port like 465
     ## by default, tracim will try to use explicit smtp encryption using starttls, and unencrypted
     ## connection as fallback.
-    email.notification.smtp.implicit_ssl = false
+    email.notification.smtp.use_implicit_ssl = false
 
 Don't forget to set `website.base_url` and `website.title` for the frontend, as some features use them to
 link the frontend in emails.

--- a/backend/doc/setting.md
+++ b/backend/doc/setting.md
@@ -4,7 +4,7 @@
 
 Most settings in Tracim are configurable using both the INI configuration file and environment variables.
 
-### Tracim 2.2 fully supported variables:
+### Tracim fully supported variables:
 
 You can set those parameters in INI configuration file (see `config_file_name`) or
 environnement variable (see `env_var_name`).
@@ -14,8 +14,8 @@ The priority order is (from less to more priority):
 - configuration file
 - environnement variables
 
-|<env_var_name>|<config_file_name>|<config_name>|
-|--------------|------------------|-------------|
+|<env_var_name>                |<config_file_name>            |<config_name>                 |
+|------------------------------|------------------------------|------------------------------|
 |TRACIM_APP__ENABLED           |app.enabled                   |APP__ENABLED                  |
 |TRACIM_SQLALCHEMY__URL        |sqlalchemy.url                |SQLALCHEMY__URL               |
 |TRACIM_DEFAULT_LANG           |default_lang                  |DEFAULT_LANG                  |
@@ -70,6 +70,7 @@ The priority order is (from less to more priority):
 |TRACIM_EMAIL__NOTIFICATION__SMTP__PORT|email.notification.smtp.port  |EMAIL__NOTIFICATION__SMTP__PORT|
 |TRACIM_EMAIL__NOTIFICATION__SMTP__USER|email.notification.smtp.user  |EMAIL__NOTIFICATION__SMTP__USER|
 |TRACIM_EMAIL__NOTIFICATION__SMTP__PASSWORD|email.notification.smtp.password|EMAIL__NOTIFICATION__SMTP__PASSWORD|
+|TRACIM_EMAIL__NOTIFICATION__SMTP__USE_IMPLICIT_SSL|email.notification.smtp.use_implicit_ssl|EMAIL__NOTIFICATION__SMTP__USE_IMPLICIT_SSL|
 |TRACIM_EMAIL__REPLY__ACTIVATED|email.reply.activated         |EMAIL__REPLY__ACTIVATED       |
 |TRACIM_EMAIL__REPLY__IMAP__SERVER|email.reply.imap.server       |EMAIL__REPLY__IMAP__SERVER    |
 |TRACIM_EMAIL__REPLY__IMAP__PORT|email.reply.imap.port         |EMAIL__REPLY__IMAP__PORT      |

--- a/backend/doc/setting.md
+++ b/backend/doc/setting.md
@@ -308,6 +308,10 @@ to enable mail notification, smallest config is this:
     email.notification.smtp.port = 1025
     email.notification.smtp.user = test_user
     email.notification.smtp.password = just_a_password
+    ## active implicit ssl if you are using implicit smtp with encryption port like 465
+    ## by default, tracim will try to use explicit smtp encryption using starttls, and unencrypted
+    ## connection as fallback.
+    email.notification.smtp.implicit_ssl = false
 
 Don't forget to set `website.base_url` and `website.title` for the frontend, as some features use them to
 link the frontend in emails.

--- a/backend/doc/setting.md
+++ b/backend/doc/setting.md
@@ -309,9 +309,9 @@ to enable mail notification, smallest config is this:
     email.notification.smtp.port = 1025
     email.notification.smtp.user = test_user
     email.notification.smtp.password = just_a_password
-    ## active implicit ssl if you are using implicit smtp with encryption port like 465
-    ## by default, tracim will try to use explicit smtp encryption using starttls, and unencrypted
-    ## connection as fallback.
+    # active implicit ssl if you are using implicit smtp with encryption port like 465
+    # by default, tracim will try to use explicit smtp encryption using starttls, and unencrypted
+    # connection as fallback.
     email.notification.smtp.use_implicit_ssl = false
 
 Don't forget to set `website.base_url` and `website.title` for the frontend, as some features use them to

--- a/backend/tracim_backend/applications/share/lib.py
+++ b/backend/tracim_backend/applications/share/lib.py
@@ -114,6 +114,7 @@ class ShareLib(object):
             config.EMAIL__NOTIFICATION__SMTP__PORT,
             config.EMAIL__NOTIFICATION__SMTP__USER,
             config.EMAIL__NOTIFICATION__SMTP__PASSWORD,
+            config.EMAIL__NOTIFICATION__SMTP__IMPLICIT_SSL,
         )
 
         return ShareEmailManager(config=config, smtp_config=smtp_config, session=session)
@@ -164,7 +165,7 @@ class ShareLib(object):
                 .filter(ContentShare.content_id == content.content_id)
                 .filter(ContentShare.share_id == share_id)
                 .one()
-            )  # type: ContentShare
+            )
         except NoResultFound as exc:
             raise ContentShareNotFound(
                 'Content Share "{}" not found in database'.format(share_id)

--- a/backend/tracim_backend/applications/share/lib.py
+++ b/backend/tracim_backend/applications/share/lib.py
@@ -164,7 +164,7 @@ class ShareLib(object):
                 self.base_query()
                 .filter(ContentShare.content_id == content.content_id)
                 .filter(ContentShare.share_id == share_id)
-                .one()
+                .one()  # type: ContentShare
             )
         except NoResultFound as exc:
             raise ContentShareNotFound(

--- a/backend/tracim_backend/applications/share/lib.py
+++ b/backend/tracim_backend/applications/share/lib.py
@@ -165,7 +165,7 @@ class ShareLib(object):
                 .filter(ContentShare.content_id == content.content_id)
                 .filter(ContentShare.share_id == share_id)
                 .one()  # type: ContentShare
-            )
+            )  # INFO - GM - 2020-04-02 - do not put typing here, black error : https://github.com/psf/black/issues/1329
         except NoResultFound as exc:
             raise ContentShareNotFound(
                 'Content Share "{}" not found in database'.format(share_id)

--- a/backend/tracim_backend/applications/share/lib.py
+++ b/backend/tracim_backend/applications/share/lib.py
@@ -114,7 +114,7 @@ class ShareLib(object):
             config.EMAIL__NOTIFICATION__SMTP__PORT,
             config.EMAIL__NOTIFICATION__SMTP__USER,
             config.EMAIL__NOTIFICATION__SMTP__PASSWORD,
-            config.EMAIL__NOTIFICATION__SMTP__IMPLICIT_SSL,
+            config.EMAIL__NOTIFICATION__SMTP__USE_IMPLICIT_SSL,
         )
 
         return ShareEmailManager(config=config, smtp_config=smtp_config, session=session)

--- a/backend/tracim_backend/applications/upload_permissions/lib.py
+++ b/backend/tracim_backend/applications/upload_permissions/lib.py
@@ -195,7 +195,7 @@ class UploadPermissionLib(object):
                 .filter(UploadPermission.workspace_id == workspace.workspace_id)
                 .filter(UploadPermission.upload_permission_id == upload_permission_id)
                 .one()  # type: UploadPermission
-            )
+            )  # INFO - GM - 2020-04-02 - do not put typing here, black error : https://github.com/psf/black/issues/1329
         except NoResultFound as exc:
             raise UploadPermissionNotFound(
                 'Upload permission "{}" not found in database'.format(upload_permission_id)

--- a/backend/tracim_backend/applications/upload_permissions/lib.py
+++ b/backend/tracim_backend/applications/upload_permissions/lib.py
@@ -131,6 +131,7 @@ class UploadPermissionLib(object):
             config.EMAIL__NOTIFICATION__SMTP__PORT,
             config.EMAIL__NOTIFICATION__SMTP__USER,
             config.EMAIL__NOTIFICATION__SMTP__PASSWORD,
+            config.EMAIL__NOTIFICATION__SMTP__IMPLICIT_SSL,
         )
 
         return UploadPermissionEmailManager(config=config, smtp_config=smtp_config, session=session)
@@ -194,7 +195,7 @@ class UploadPermissionLib(object):
                 .filter(UploadPermission.workspace_id == workspace.workspace_id)
                 .filter(UploadPermission.upload_permission_id == upload_permission_id)
                 .one()
-            )  # type: UploadPermission
+            )
         except NoResultFound as exc:
             raise UploadPermissionNotFound(
                 'Upload permission "{}" not found in database'.format(upload_permission_id)

--- a/backend/tracim_backend/applications/upload_permissions/lib.py
+++ b/backend/tracim_backend/applications/upload_permissions/lib.py
@@ -131,7 +131,7 @@ class UploadPermissionLib(object):
             config.EMAIL__NOTIFICATION__SMTP__PORT,
             config.EMAIL__NOTIFICATION__SMTP__USER,
             config.EMAIL__NOTIFICATION__SMTP__PASSWORD,
-            config.EMAIL__NOTIFICATION__SMTP__IMPLICIT_SSL,
+            config.EMAIL__NOTIFICATION__SMTP__USE_IMPLICIT_SSL,
         )
 
         return UploadPermissionEmailManager(config=config, smtp_config=smtp_config, session=session)

--- a/backend/tracim_backend/applications/upload_permissions/lib.py
+++ b/backend/tracim_backend/applications/upload_permissions/lib.py
@@ -194,7 +194,7 @@ class UploadPermissionLib(object):
                 self.base_query()
                 .filter(UploadPermission.workspace_id == workspace.workspace_id)
                 .filter(UploadPermission.upload_permission_id == upload_permission_id)
-                .one()
+                .one()  # type: UploadPermission
             )
         except NoResultFound as exc:
             raise UploadPermissionNotFound(

--- a/backend/tracim_backend/config.py
+++ b/backend/tracim_backend/config.py
@@ -498,6 +498,9 @@ class CFG(object):
         self.EMAIL__NOTIFICATION__SMTP__PASSWORD = self.get_raw_config(
             "email.notification.smtp.password", secret=True
         )
+        self.EMAIL__NOTIFICATION__SMTP__IMPLICIT_SSL = asbool(
+            self.get_raw_config("email.notification.smtp.implicit_ssl", "false")
+        )
 
         self.EMAIL__REPLY__ACTIVATED = asbool(self.get_raw_config("email.reply.activated", "false"))
 

--- a/backend/tracim_backend/config.py
+++ b/backend/tracim_backend/config.py
@@ -498,8 +498,8 @@ class CFG(object):
         self.EMAIL__NOTIFICATION__SMTP__PASSWORD = self.get_raw_config(
             "email.notification.smtp.password", secret=True
         )
-        self.EMAIL__NOTIFICATION__SMTP__IMPLICIT_SSL = asbool(
-            self.get_raw_config("email.notification.smtp.implicit_ssl", "false")
+        self.EMAIL__NOTIFICATION__SMTP__USE_IMPLICIT_SSL = asbool(
+            self.get_raw_config("email.notification.smtp.use_implicit_ssl", "false")
         )
 
         self.EMAIL__REPLY__ACTIVATED = asbool(self.get_raw_config("email.reply.activated", "false"))

--- a/backend/tracim_backend/lib/mail_fetcher/email_fetcher.py
+++ b/backend/tracim_backend/lib/mail_fetcher/email_fetcher.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 from email import message_from_bytes
 from email.header import decode_header
 from email.header import make_header

--- a/backend/tracim_backend/lib/mail_notifier/notifier.py
+++ b/backend/tracim_backend/lib/mail_notifier/notifier.py
@@ -52,7 +52,7 @@ class EmailNotifier(INotifier):
             self.config.EMAIL__NOTIFICATION__SMTP__PORT,
             self.config.EMAIL__NOTIFICATION__SMTP__USER,
             self.config.EMAIL__NOTIFICATION__SMTP__PASSWORD,
-            self.config.EMAIL__NOTIFICATION__SMTP__IMPLICIT_SSL,
+            self.config.EMAIL__NOTIFICATION__SMTP__USE_IMPLICIT_SSL,
         )
 
     def notify_content_update(self, content: Content):
@@ -558,7 +558,7 @@ def get_email_manager(config: CFG, session: Session):
         config.EMAIL__NOTIFICATION__SMTP__PORT,
         config.EMAIL__NOTIFICATION__SMTP__USER,
         config.EMAIL__NOTIFICATION__SMTP__PASSWORD,
-        config.EMAIL__NOTIFICATION__SMTP__IMPLICIT_SSL,
+        config.EMAIL__NOTIFICATION__SMTP__USE_IMPLICIT_SSL,
     )
 
     return EmailManager(config=config, smtp_config=smtp_config, session=session)

--- a/backend/tracim_backend/lib/mail_notifier/notifier.py
+++ b/backend/tracim_backend/lib/mail_notifier/notifier.py
@@ -52,6 +52,7 @@ class EmailNotifier(INotifier):
             self.config.EMAIL__NOTIFICATION__SMTP__PORT,
             self.config.EMAIL__NOTIFICATION__SMTP__USER,
             self.config.EMAIL__NOTIFICATION__SMTP__PASSWORD,
+            self.config.EMAIL__NOTIFICATION__SMTP__IMPLICIT_SSL,
         )
 
     def notify_content_update(self, content: Content):
@@ -557,6 +558,7 @@ def get_email_manager(config: CFG, session: Session):
         config.EMAIL__NOTIFICATION__SMTP__PORT,
         config.EMAIL__NOTIFICATION__SMTP__USER,
         config.EMAIL__NOTIFICATION__SMTP__PASSWORD,
+        config.EMAIL__NOTIFICATION__SMTP__IMPLICIT_SSL,
     )
 
     return EmailManager(config=config, smtp_config=smtp_config, session=session)

--- a/backend/tracim_backend/lib/mail_notifier/sender.py
+++ b/backend/tracim_backend/lib/mail_notifier/sender.py
@@ -63,7 +63,7 @@ class EmailSender(object):
         if not self._smtp_connection:
             log = "Connecting to SMTP server {}"
             logger.info(self, log.format(self._smtp_config.server))
-            if self._smtp_config.implicit_ssl:
+            if self._smtp_config.use_implicit_ssl:
                 self._smtp_connection = smtplib.SMTP_SSL(
                     self._smtp_config.server, self._smtp_config.port
                 )
@@ -73,7 +73,7 @@ class EmailSender(object):
                 )
             self._smtp_connection.ehlo()
 
-            if self._smtp_config.login and not self._smtp_config.implicit_ssl:
+            if self._smtp_config.login and not self._smtp_config.use_implicit_ssl:
                 try:
                     starttls_result = self._smtp_connection.starttls()
 

--- a/backend/tracim_backend/lib/mail_notifier/sender.py
+++ b/backend/tracim_backend/lib/mail_notifier/sender.py
@@ -73,6 +73,8 @@ class EmailSender(object):
                 )
             self._smtp_connection.ehlo()
 
+            # TODO - G.M - 2020-04-02 - Starttls usage should be explicit in configuration, see
+            # https://github.com/tracim/tracim/issues/2815
             if self._smtp_config.login and not self._smtp_config.use_implicit_ssl:
                 try:
                     starttls_result = self._smtp_connection.starttls()

--- a/backend/tracim_backend/lib/mail_notifier/sender.py
+++ b/backend/tracim_backend/lib/mail_notifier/sender.py
@@ -63,12 +63,17 @@ class EmailSender(object):
         if not self._smtp_connection:
             log = "Connecting to SMTP server {}"
             logger.info(self, log.format(self._smtp_config.server))
-            # TODO - G.M - 2019-01-29 - Support for SMTP SSL-only port connection
-            # using smtplib.SMTP_SSL
-            self._smtp_connection = smtplib.SMTP(self._smtp_config.server, self._smtp_config.port)
+            if self._smtp_config.implicit_ssl:
+                self._smtp_connection = smtplib.SMTP_SSL(
+                    self._smtp_config.server, self._smtp_config.port
+                )
+            else:
+                self._smtp_connection = smtplib.SMTP(
+                    self._smtp_config.server, self._smtp_config.port
+                )
             self._smtp_connection.ehlo()
 
-            if self._smtp_config.login:
+            if self._smtp_config.login and not self._smtp_config.implicit_ssl:
                 try:
                     starttls_result = self._smtp_connection.starttls()
 

--- a/backend/tracim_backend/lib/mail_notifier/utils.py
+++ b/backend/tracim_backend/lib/mail_notifier/utils.py
@@ -1,12 +1,12 @@
 class SmtpConfiguration(object):
     """Container class for SMTP configuration used in Tracim."""
 
-    def __init__(self, server: str, port: int, login: str, password: str, implicit_ssl: bool):
+    def __init__(self, server: str, port: int, login: str, password: str, use_implicit_ssl: bool):
         self.server = server
         self.port = port
         self.login = login
         self.password = password
-        self.implicit_ssl = implicit_ssl
+        self.use_implicit_ssl = use_implicit_ssl
 
 
 class EST(object):

--- a/backend/tracim_backend/lib/mail_notifier/utils.py
+++ b/backend/tracim_backend/lib/mail_notifier/utils.py
@@ -1,11 +1,12 @@
 class SmtpConfiguration(object):
     """Container class for SMTP configuration used in Tracim."""
 
-    def __init__(self, server: str, port: int, login: str, password: str):
+    def __init__(self, server: str, port: int, login: str, password: str, implicit_ssl: bool):
         self.server = server
         self.port = port
         self.login = login
         self.password = password
+        self.implicit_ssl = implicit_ssl
 
 
 class EST(object):

--- a/backend/tracim_backend/tests/functional/test_mail_notification.py
+++ b/backend/tracim_backend/tests/functional/test_mail_notification.py
@@ -23,6 +23,7 @@ class TestEmailSender(object):
             app_config.EMAIL__NOTIFICATION__SMTP__PORT,
             app_config.EMAIL__NOTIFICATION__SMTP__USER,
             app_config.EMAIL__NOTIFICATION__SMTP__PASSWORD,
+            app_config.EMAIL__NOTIFICATION__SMTP__IMPLICIT_SSL,
         )
         sender = EmailSender(app_config, smtp_config, True)
         sender.connect()
@@ -34,6 +35,7 @@ class TestEmailSender(object):
             app_config.EMAIL__NOTIFICATION__SMTP__PORT,
             app_config.EMAIL__NOTIFICATION__SMTP__USER,
             app_config.EMAIL__NOTIFICATION__SMTP__PASSWORD,
+            app_config.EMAIL__NOTIFICATION__SMTP__IMPLICIT_SSL,
         )
         sender = EmailSender(app_config, smtp_config, True)
 

--- a/backend/tracim_backend/tests/functional/test_mail_notification.py
+++ b/backend/tracim_backend/tests/functional/test_mail_notification.py
@@ -23,7 +23,7 @@ class TestEmailSender(object):
             app_config.EMAIL__NOTIFICATION__SMTP__PORT,
             app_config.EMAIL__NOTIFICATION__SMTP__USER,
             app_config.EMAIL__NOTIFICATION__SMTP__PASSWORD,
-            app_config.EMAIL__NOTIFICATION__SMTP__IMPLICIT_SSL,
+            app_config.EMAIL__NOTIFICATION__SMTP__USE_IMPLICIT_SSL,
         )
         sender = EmailSender(app_config, smtp_config, True)
         sender.connect()
@@ -35,7 +35,7 @@ class TestEmailSender(object):
             app_config.EMAIL__NOTIFICATION__SMTP__PORT,
             app_config.EMAIL__NOTIFICATION__SMTP__USER,
             app_config.EMAIL__NOTIFICATION__SMTP__PASSWORD,
-            app_config.EMAIL__NOTIFICATION__SMTP__IMPLICIT_SSL,
+            app_config.EMAIL__NOTIFICATION__SMTP__USE_IMPLICIT_SSL,
         )
         sender = EmailSender(app_config, smtp_config, True)
 


### PR DESCRIPTION
add a boolean config parameter `email.notification.use_implicit_ssl` to active implicit encryption for smtp (ssl over smtp, most of the time on port 465) and code needed to support this feature.

related to #2793 

## Checkpoints

**For code reviewer**

- [x] Code is clear enough
- [x] If there are FIXME in the code, then there are associated issues and issue is referenced in the FIXME
- [x] If there are TODO, NOTE or HACK in code, date and developer initials are present
- [x] Automated tests have been written (covering feature or non regression), or *at least* an issue has been created for test implementation

**For developper**

- [x] Manual tests done to ensure stability on whole application layers, issue expectation follow
- [x] Original issue have been updated with a short resume of implemented solution

**For quality team**

- [x] Tested by quality team
