### PR TITLE
[For 2.6.3] avoid logging exception string value, log traceback instead

### DIFF
--- a/backend/tracim_backend/lib/core/content.py
+++ b/backend/tracim_backend/lib/core/content.py
@@ -2,7 +2,6 @@
 from contextlib import contextmanager
 import datetime
 import os
-import traceback
 import typing
 
 from depot.io.interfaces import StoredFile
@@ -954,17 +953,13 @@ class ContentApi(object):
             ) from exc
         except RevisionFilePathSearchFailedDepotCorrupted as exc:
             logger.warning(
-                self, "Unable to get revision filepath, depot is corrupted: {}".format(str(exc))
+                self, "Unable to get revision filepath, depot is corrupted", exc_info=True
             )
-            logger.warning(self, traceback.format_exc())
             raise UnavailablePreview(
                 "No preview available for content {}, revision {}".format(content_id, revision_id)
             ) from exc
         except Exception as exc:
-            logger.warning(
-                self, "Unknown Preview_Generator Exception Occured : {}".format(str(exc))
-            )
-            logger.warning(self, traceback.format_exc())
+            logger.warning(self, "Unknown Preview_Generator Exception Occured", exc_info=True)
             raise UnavailablePreview(
                 "No preview available for content {}, revision {}".format(content_id, revision_id)
             ) from exc
@@ -990,17 +985,13 @@ class ContentApi(object):
             ) from exc
         except RevisionFilePathSearchFailedDepotCorrupted as exc:
             logger.warning(
-                self, "Unable to get revision filepath, depot is corrupted: {}".format(str(exc))
+                self, "Unable to get revision filepath, depot is corrupted", exc_info=True
             )
-            logger.warning(self, traceback.format_exc())
             raise UnavailablePreview(
                 "No preview available for revision {}".format(revision_id)
             ) from exc
         except Exception as exc:
-            logger.warning(
-                self, "Unknown Preview_Generator Exception Occured : {}".format(str(exc))
-            )
-            logger.warning(self, traceback.format_exc())
+            logger.warning(self, "Unknown Preview_Generator Exception Occured", exc_info=True)
             raise UnavailablePreview(
                 "No preview available for revision {}".format(revision_id)
             ) from exc
@@ -1072,17 +1063,13 @@ class ContentApi(object):
             ) from exc
         except RevisionFilePathSearchFailedDepotCorrupted as exc:
             logger.warning(
-                self, "Unable to get revision filepath, depot is corrupted: {}".format(str(exc))
+                self, "Unable to get revision filepath, depot is corrupted", exc_info=True
             )
-            logger.warning(self, traceback.format_exc())
             raise UnavailablePreview(
                 "No preview available for content {}, revision {}".format(content_id, revision_id)
             ) from exc
         except Exception as exc:
-            logger.warning(
-                self, "Unknown Preview_Generator Exception Occured : {}".format(str(exc))
-            )
-            logger.warning(self, traceback.format_exc())
+            logger.warning(self, "Unknown Preview_Generator Exception Occured", exc_info=True)
             raise UnavailablePreview(
                 "No preview available for content {}, revision {}".format(content_id, revision_id)
             ) from exc
@@ -2008,15 +1995,13 @@ class ContentApi(object):
             nb_pages = self.preview_manager.get_page_nb(file_path, file_ext=file_extension)
         except UnsupportedMimeType:
             return None
-        except RevisionFilePathSearchFailedDepotCorrupted as exc:
+        except RevisionFilePathSearchFailedDepotCorrupted:
             logger.warning(
-                self, "Unable to get revision filepath, depot is corrupted: {}".format(str(exc))
+                self, "Unable to get revision filepath, depot is corrupted", exc_info=True
             )
-            logger.warning(self, traceback.format_exc())
             return None
-        except Exception as e:
-            logger.warning(self, "Unknown Preview_Generator Exception Occured : {}".format(str(e)))
-            logger.warning(self, traceback.format_exc())
+        except Exception:
+            logger.warning(self, "Unknown Preview_Generator Exception Occured", exc_info=True)
             return None
         return nb_pages
 
@@ -2026,15 +2011,13 @@ class ContentApi(object):
             return self.preview_manager.has_pdf_preview(file_path, file_ext=file_extension)
         except UnsupportedMimeType:
             return False
-        except RevisionFilePathSearchFailedDepotCorrupted as exc:
+        except RevisionFilePathSearchFailedDepotCorrupted:
             logger.warning(
-                self, "Unable to get revision filepath, depot is corrupted: {}".format(str(exc))
+                self, "Unable to get revision filepath, depot is corrupted", exc_info=True
             )
-            logger.warning(self, traceback.format_exc())
             return False
-        except Exception as e:
-            logger.warning(self, "Unknown Preview_Generator Exception Occured : {}".format(str(e)))
-            logger.warning(self, traceback.format_exc())
+        except Exception:
+            logger.warning(self, "Unknown Preview_Generator Exception Occured", exc_info=True)
             return False
 
     def has_jpeg_preview(self, revision_id: int, file_extension: str) -> bool:
@@ -2043,15 +2026,13 @@ class ContentApi(object):
             return self.preview_manager.has_jpeg_preview(file_path, file_ext=file_extension)
         except UnsupportedMimeType:
             return False
-        except RevisionFilePathSearchFailedDepotCorrupted as exc:
+        except RevisionFilePathSearchFailedDepotCorrupted:
             logger.warning(
-                self, "Unable to get revision filepath, depot is corrupted: {}".format(str(exc))
+                self, "Unable to get revision filepath, depot is corrupted", exc_info=True
             )
-            logger.warning(self, traceback.format_exc())
             return False
-        except Exception as e:
-            logger.warning(self, "Unknown Preview_Generator Exception Occured : {}".format(str(e)))
-            logger.warning(self, traceback.format_exc())
+        except Exception:
+            logger.warning(self, "Unknown Preview_Generator Exception Occured", exc_info=True)
             return False
 
     def mark_read__all(

--- a/backend/tracim_backend/lib/mail_fetcher/email_fetcher.py
+++ b/backend/tracim_backend/lib/mail_fetcher/email_fetcher.py
@@ -344,43 +344,38 @@ class MailFetcher(object):
                         self.stop()
                         break
             # Socket
-            except (socket.error, socket.gaierror, socket.herror) as e:
-                log = "Socket fail with IMAP connection {}"
-                logger.error(self, log.format(e.__str__()))
-
-            except socket.timeout as e:
-                log = "Socket timeout on IMAP connection {}"
-                logger.error(self, log.format(e.__str__()))
-
+            except (socket.error, socket.gaierror, socket.herror):
+                log = "Socket fail with IMAP connection"
+                logger.exception(self, log)
+            except socket.timeout:
+                log = "Socket timeout on IMAP connection"
+                logger.exception(self, log)
             # SSL
-            except ssl.SSLError as e:
+            except ssl.SSLError:
                 log = "SSL error on IMAP connection"
-                logger.error(self, log.format(e.__str__()))
-
-            except ssl.CertificateError as e:
+                logger.exception(self, log)
+            except ssl.CertificateError:
                 log = "SSL Certificate verification failed on IMAP connection"
-                logger.error(self, log.format(e.__str__()))
-
+                logger.exception(self, log)
             # Filelock
-            except filelock.Timeout as e:
-                log = "Mail Fetcher Lock Timeout {}"
-                logger.warning(self, log.format(e.__str__()))
+            except filelock.Timeout:
+                log = "Mail Fetcher Lock Timeout"
+                logger.warning(self, log, exc_info=True)
 
             # IMAP
             # TODO - G.M - 10-01-2017 - Support imapclient exceptions
             # when Imapclient stable will be 2.0+
 
-            except BadIMAPFetchResponse as e:
+            except BadIMAPFetchResponse:
                 log = (
                     "Imap Fetch command return bad response."
-                    "Is someone else connected to the mailbox ?: "
-                    "{}"
+                    "Is someone else connected to the mailbox ?"
                 )
-                logger.error(self, log.format(e.__str__()))
+                logger.exception(self, log)
             # Others
-            except Exception as e:
-                log = "Mail Fetcher error {}"
-                logger.error(self, log.format(e.__str__()))
+            except Exception:
+                log = "Mail Fetcher error"
+                logger.exception(self, log)
 
             finally:
                 # INFO - G.M - 2018-01-09 - Connection closing
@@ -395,9 +390,9 @@ class MailFetcher(object):
                     except Exception:
                         try:
                             imapc.shutdown()
-                        except Exception as e:
-                            log = "Can't logout, connection broken ? {}"
-                            logger.error(self, log.format(e.__str__()))
+                        except Exception:
+                            log = "Can't logout, connection broken ?"
+                            logger.exception(self, log)
 
             if self.burst:
                 self.stop()
@@ -471,9 +466,9 @@ class MailFetcher(object):
             mail = mails.pop()
             try:
                 method, endpoint, json_body_dict = self._create_comment_request(mail)
-            except NoSpecialKeyFound as exc:
-                log = "Failed to create comment request due to missing specialkey in mail {}"
-                logger.error(self, log.format(exc.__str__()))
+            except NoSpecialKeyFound:
+                log = "Failed to create comment request due to missing specialkey in mail"
+                logger.exception(self, log)
                 continue
             except EmptyEmailBody:
                 log = "Empty body, skip mail"
@@ -483,9 +478,9 @@ class MailFetcher(object):
                 log = "Autoreply mail, skip mail"
                 logger.warning(self, log)
                 continue
-            except Exception as exc:
-                log = "Failed to create comment request in mail fetcher error : {}"
-                logger.error(self, log.format(exc.__str__()))
+            except Exception:
+                log = "Failed to create comment request in mail fetcher error"
+                logger.exception(self, log)
                 continue
 
             try:
@@ -496,12 +491,12 @@ class MailFetcher(object):
                     endpoint=endpoint,
                     json_body_dict=json_body_dict,
                 )
-            except requests.exceptions.Timeout as e:
-                log = "Timeout error to transmit fetched mail to tracim : {}"
-                logger.error(self, log.format(str(e)))
-            except requests.exceptions.RequestException as e:
-                log = "Fail to transmit fetched mail to tracim : {}"
-                logger.error(self, log.format(str(e)))
+            except requests.exceptions.Timeout:
+                log = "Timeout error to transmit fetched mail to tracim"
+                logger.exception(self, log)
+            except requests.exceptions.RequestException:
+                log = "Fail to transmit fetched mail to tracim"
+                logger.exception(self, log)
 
     def _get_auth_headers(self, user_email) -> dict:
         return {TRACIM_API_KEY_HEADER: self.api_key, TRACIM_API_USER_EMAIL_LOGIN_HEADER: user_email}

--- a/backend/tracim_backend/lib/mail_notifier/notifier.py
+++ b/backend/tracim_backend/lib/mail_notifier/notifier.py
@@ -122,12 +122,8 @@ class EmailNotifier(INotifier):
                 EmailManager(self._smtp_config, self.config, self.session).notify_content_update(
                     self._user.user_id, content.content_id
                 )
-        except Exception as e:
-            # TODO - G.M - 2018-08-27 - Do Better catching for exception here
-            logger.error(
-                self, "Exception catched during email notification: {}".format(e.__str__())
-            )
-            logger.exception(self, e)
+        except Exception:
+            logger.exception(self, "Exception catched during email notification")
 
 
 class EmailManager(object):
@@ -455,9 +451,9 @@ class EmailManager(object):
                 lang=translator.default_lang,
                 **context
             )
-        except Exception as exc:
-            logger.exception(self, "Failed to render email template: {}".format(exc.__str__()))
-            raise EmailTemplateError("Failed to render email template: {}".format(exc.__str__()))
+        except Exception:
+            logger.exception(self, "Failed to render email template")
+            raise EmailTemplateError("Failed to render email template")
 
     def _build_context_for_content_update(
         self,

--- a/backend/tracim_backend/lib/mail_notifier/sender.py
+++ b/backend/tracim_backend/lib/mail_notifier/sender.py
@@ -2,7 +2,6 @@
 from email.message import Message
 from email.mime.multipart import MIMEMultipart
 import smtplib
-import traceback
 import typing
 
 from tracim_backend.config import CFG
@@ -82,10 +81,9 @@ class EmailSender(object):
                 except smtplib.SMTPResponseException as exc:
                     log = "SMTP start TLS return error code: {} with message: {}"
                     logger.error(self, log.format(exc.smtp_code, exc.smtp_error.decode("utf-8")))
-                except Exception as exc:
-                    log = "Unexpected exception during SMTP start TLS process: {}"
-                    logger.error(self, log.format(exc.__str__()))
-                    logger.error(self, traceback.format_exc())
+                except Exception:
+                    log = "Unexpected exception during SMTP start TLS process"
+                    logger.exception(self, log)
 
             if self._smtp_config.login:
                 try:
@@ -101,7 +99,6 @@ class EmailSender(object):
                     log = "SMTP login return code: {} with message: {}"
                     logger.debug(self, log.format(login_res[0], login_res[1].decode("utf-8")))
                 except smtplib.SMTPAuthenticationError as exc:
-
                     log = "SMTP auth return error code: {} with message: {}"
                     logger.error(self, log.format(exc.smtp_code, exc.smtp_error.decode("utf-8")))
                     logger.error(
@@ -110,10 +107,9 @@ class EmailSender(object):
                 except smtplib.SMTPResponseException as exc:
                     log = "SMTP login return error code: {} with message: {}"
                     logger.error(self, log.format(exc.smtp_code, exc.smtp_error.decode("utf-8")))
-                except Exception as exc:
-                    log = "Unexpected exception during SMTP login {}"
-                    logger.error(self, log.format(exc.__str__()))
-                    logger.error(self, traceback.format_exc())
+                except Exception:
+                    log = "Unexpected exception during SMTP login"
+                    logger.exception(self, log)
 
     def disconnect(self):
         if self._smtp_connection:
@@ -152,14 +148,13 @@ class EmailSender(object):
                     logger.debug(self, log.format(send_message_result))
                     action = failed_action
 
-            except smtplib.SMTPException as exc:
-                log = "SMTP sending message return error: {}"
-                logger.error(self, log.format(str(exc)))
+            except smtplib.SMTPException:
+                log = "SMTP sending message return error"
+                logger.exception(self, log)
                 action = failed_action
-            except Exception as exc:
-                log = "Unexpected exception during sending email message using SMTP: {}"
-                logger.error(self, log.format(exc.__str__()))
-                logger.error(self, traceback.format_exc())
+            except Exception:
+                log = "Unexpected exception during sending email message using SMTP"
+                logger.exception(self, log)
                 action = failed_action
 
             from tracim_backend.lib.mail_notifier.notifier import EmailManager

--- a/backend/tracim_backend/lib/utils/logger.py
+++ b/backend/tracim_backend/lib/utils/logger.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 import time
+import typing
 
 from colorlog import colorlog
 
@@ -20,36 +21,37 @@ class Logger(object):
 
     TPL = "[{cls}] {msg}"
 
-    def __init__(self, logger_name):
+    def __init__(self, logger_name: str):
         self._name = logger_name
         self._logger = logging.getLogger(self._name)
 
     @classmethod
-    def _txt(cls, instance_or_class):
+    def _txt(cls, instance_or_class: typing.Any):
         if instance_or_class.__class__.__name__ in ("function", "type"):
             return instance_or_class.__name__
         else:
             return instance_or_class.__class__.__name__
 
-    def debug(self, instance_or_class, message):
-        self._logger.debug(Logger.TPL.format(cls=self._txt(instance_or_class), msg=message))
+    def _msg(self, instance_or_class: typing.Any, msg: str):
+        return Logger.TPL.format(cls=self._txt(instance_or_class), msg=msg)
 
-    def error(self, instance_or_class, message, exc_info=0):
-        self._logger.error(
-            Logger.TPL.format(cls=self._txt(instance_or_class), msg=message, exc_info=exc_info)
-        )
+    def debug(self, instance_or_class, message: str, exc_info: bool = False):
+        self._logger.debug(msg=self._msg(instance_or_class, message), exc_info=exc_info)
 
-    def info(self, instance_or_class, message):
-        self._logger.info(Logger.TPL.format(cls=self._txt(instance_or_class), msg=message))
+    def error(self, instance_or_class, message: str, exc_info: bool = False):
+        self._logger.error(msg=self._msg(instance_or_class, message), exc_info=exc_info)
 
-    def warning(self, instance_or_class, message):
-        self._logger.warning(Logger.TPL.format(cls=self._txt(instance_or_class), msg=message))
+    def info(self, instance_or_class, message: str, exc_info: bool = False):
+        self._logger.info(msg=self._msg(instance_or_class, message), exc_info=exc_info)
 
-    def critical(self, instance_or_class, message):
-        self._logger.critical(Logger.TPL.format(cls=self._txt(instance_or_class), msg=message))
+    def warning(self, instance_or_class, message: str, exc_info: bool = False):
+        self._logger.warning(msg=self._msg(instance_or_class, message), exc_info=exc_info)
 
-    def exception(self, instance_or_class, message):
-        self._logger.exception(Logger.TPL.format(cls=self._txt(instance_or_class), msg=message))
+    def critical(self, instance_or_class, message: str, exc_info: bool = False):
+        self._logger.critical(msg=self._msg(instance_or_class, message), exc_info=exc_info)
+
+    def exception(self, instance_or_class, message: str):
+        self._logger.exception(msg=self._msg(instance_or_class, message),)
 
 
 logger = Logger("tracim")

--- a/backend/tracim_backend/models/context_models.py
+++ b/backend/tracim_backend/models/context_models.py
@@ -3,7 +3,6 @@ import base64
 import cgi
 from datetime import datetime
 from enum import Enum
-import traceback
 import typing
 
 from slugify import slugify
@@ -1136,17 +1135,14 @@ class ContentInContext(object):
             return None
         try:
             return self.content.depot_file.file.content_length
-        except IOError as e:
+        except IOError:
             logger.warning(
-                self, "IO Exception Occured when trying to get content size  : {}".format(str(e))
+                self, "IO Exception Occured when trying to get content size", exc_info=True
             )
-            logger.warning(self, traceback.format_exc())
-        except Exception as e:
+        except Exception:
             logger.warning(
-                self,
-                "Unknown Exception Occured when trying to get content size  : {}".format(str(e)),
+                self, "Unknown Exception Occured when trying to get content size", exc_info=True
             )
-            logger.warning(self, traceback.format_exc())
         return None
 
     @property
@@ -1440,17 +1436,14 @@ class RevisionInContext(object):
             return None
         try:
             return self.revision.depot_file.file.content_length
-        except IOError as e:
+        except IOError:
             logger.warning(
-                self, "IO Exception Occured when trying to get content size  : {}".format(str(e))
+                self, "IO Exception Occured when trying to get content size", exc_info=True
             )
-            logger.warning(self, traceback.format_exc())
-        except Exception as e:
+        except Exception:
             logger.warning(
-                self,
-                "Unknown Exception Occured when trying to get content size  : {}".format(str(e)),
+                self, "Unknown Exception Occured when trying to get content size", exc_info=True
             )
-            logger.warning(self, traceback.format_exc())
         return None
 
     @property


### PR DESCRIPTION
Related to #2812 

Done:
- refactor Logger
- remove all exception string value logging and replace them to exc_info=true option or logger.exception() method

:warning: **Reviewers**: please take time to reviews this code, this code change code for many error case that are not well tested because they does not occured in normal working Tracim, some are needed to ensure daemon does not failed at all for example. So, please have this in mind when reviewing this code, in order to avoid "broken code" that we don't see at all.

## Checkpoints

The goal of this section is to help code reviewer and merge request author to do required checks on this pull request. Please don't edit this list.
If one or more of these checkpoints are out of scope, please write below why they are.

**For code reviewer**

- [x] Code is clear enough
- [x] If there are FIXME in the code, then there are associated issues and issue is referenced in the FIXME
- [x] If there are TODO, NOTE or HACK in code, date and developer initials are present
- [x] Automated tests have been written (covering feature or non regression), or *at least* an issue has been created for test implementation

**For developper**

- [x] Manual tests done to ensure stability on whole application layers, issue expectation follow
- [x] Original issue have been updated with a short resume of implemented solution

**For quality team**

- [x] Tested by quality team
