### PR TITLE
[For 2.7.0] Fix upload icon in FileDropzone

### DIFF
--- a/frontend_lib/src/component/FileDropzone/FileDropzone.jsx
+++ b/frontend_lib/src/component/FileDropzone/FileDropzone.jsx
@@ -23,7 +23,7 @@ export const FileDropzone = props => {
                     className='filecontent__form__icon d-flex justify-content-center'
                     style={{ color: props.hexcolor }}
                   >
-                    <i className='fa fa-download' />
+                    <i className='fa fa-upload' />
                   </div>
 
                   <div


### PR DESCRIPTION
Related to this fix: #2444 
Use `fa-upload` instead of `fa-download` in FileDropzone

## Checkpoints

The goal of this section is to help code reviewer and merge request author to do required checks on this pull request. Please don't edit this list.
If one or more of these checkpoints are out of scope, please write below why they are.

**For code reviewer**

- [x] Code is clear enough
- [x] If there are FIXME in the code, then there are associated issues and issue is referenced in the FIXME
- [x] If there are TODO, NOTE or HACK in code, date and developer initials are present
- [x] Automated tests have been written (covering feature or non regression), or *at least* an issue has been created for test implementation

**For developper**

- [x] Manual tests done to ensure stability on whole application layers, issue expectation follow
- [x] Original issue have been updated with a short resume of implemented solution

**For quality team**

- [x] Tested by quality team
