### PR TITLE
fix(dep): support any installed version of yarn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ previews
 
 #ignore yarn
 .yarn
+.yarnrc
 .yarnrc.yml
 node_modules
 

--- a/install_frontend_dependencies.sh
+++ b/install_frontend_dependencies.sh
@@ -121,9 +121,9 @@ debian_install() {
 }
 
 setup_yarn() {
-    if [ ! -f ".yarnrc.yml" ]; then
-        log "Setting up yarn (yarn set version berry)"
-        yarn set version berry && \
+    if ! yarn -v | grep '^2\.' > /dev/null; then
+        log "Setting up yarn (yarn policies set-version berry)"
+        yarn policies set-version berry && \
             loggood "Yarn is correctly set up." || \
             logerror "Failed to set up yarn."
     fi
@@ -132,7 +132,7 @@ setup_yarn() {
         logerror "We expected Yarn 2, we got $(yarn --version)."
     fi
 
-    if ! grep -F 'nodeLinker: node-modules' .yarnrc.yml; then
+    if ! grep -F 'nodeLinker: node-modules' .yarnrc.yml > /dev/null; then
         log "Setting yarn nodeLinker to node-modules mode."
         echo 'nodeLinker: node-modules' >> .yarnrc.yml
     fi


### PR DESCRIPTION
Related to #2918.
This allows using any installed version of yarn on the developer's system.

The fix consists in using command `yarn policies set-version berry` instead of `yarn set version berry` and checking that Yarn is not already version 2.

## Checkpoints

- [x] Code is clear enough
- [x] If there are FIXME in the code, then there are associated issues and issue is referenced in the FIXME
- [x] If there are TODO, NOTE or HACK in code, date and developer initials are present
- [x] Automated tests have been written (covering feature or non regression), or *at least* an issue has been created for test implementation

**For developer**

- [x] Manual tests done to ensure stability on whole application layers, issue expectation follow
- [x] Original issue have been updated with a short resume of implemented solution

**For quality team**

- [x] Tested by quality team
