### PR TITLE
Feature/3095  content type in event type

### DIFF
--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -2,5 +2,6 @@
 minversion = 2.8
 testpaths = tracim_backend
 addopts = -s -v
+filterwarnings = ignore:.*:Warning
 env_files =
     .test.env

--- a/backend/tests_configs.ini
+++ b/backend/tests_configs.ini
@@ -202,6 +202,7 @@ email.notification.enabled_on_invitation = False
 webdav.ui.enabled = False
 webdav.base_url = https://localhost:3030
 webdav.root_path = /webdav
+debug = True
 
 [functional_test_with_trusted_user_as_default_profile]
 app.enabled = contents/thread,contents/file,contents/html-document,contents/folder,upload_permission,share_content

--- a/backend/tests_configs.ini
+++ b/backend/tests_configs.ini
@@ -202,7 +202,6 @@ email.notification.enabled_on_invitation = False
 webdav.ui.enabled = False
 webdav.base_url = https://localhost:3030
 webdav.root_path = /webdav
-debug = True
 
 [functional_test_with_trusted_user_as_default_profile]
 app.enabled = contents/thread,contents/file,contents/html-document,contents/folder,upload_permission,share_content

--- a/backend/tracim_backend/app_models/contents.py
+++ b/backend/tracim_backend/app_models/contents.py
@@ -167,6 +167,7 @@ FILE_TYPE = "file"
 MARKDOWNPLUSPAGE_TYPE = "markdownpage"
 HTML_DOCUMENTS_TYPE = "html-document"
 FOLDER_TYPE = "folder"
+COMMENT_TYPE = "comment"
 
 # TODO - G.M - 31-05-2018 - Set Better Event params
 event_type = TracimContentType(
@@ -180,7 +181,7 @@ event_type = TracimContentType(
 
 # TODO - G.M - 31-05-2018 - Set Better Event params
 comment_type = TracimContentType(
-    slug="comment",
+    slug=COMMENT_TYPE,
     fa_icon="",
     label="Comment",
     creation_label="Comment",

--- a/backend/tracim_backend/lib/core/event.py
+++ b/backend/tracim_backend/lib/core/event.py
@@ -6,6 +6,11 @@ from sqlalchemy import inspect
 from sqlalchemy import null
 from sqlalchemy.orm import joinedload
 
+from tracim_backend.app_models.contents import COMMENT_TYPE
+from tracim_backend.app_models.contents import FILE_TYPE
+from tracim_backend.app_models.contents import FOLDER_TYPE
+from tracim_backend.app_models.contents import HTML_DOCUMENTS_TYPE
+from tracim_backend.app_models.contents import THREAD_TYPE
 from tracim_backend.config import CFG
 from tracim_backend.exceptions import UserDoesNotExist
 from tracim_backend.lib.core.content import ContentApi
@@ -31,8 +36,10 @@ from tracim_backend.models.event import Message
 from tracim_backend.models.event import OperationType
 from tracim_backend.models.event import ReadStatus
 from tracim_backend.models.tracim_session import TracimSession
-from tracim_backend.views.core_api.schemas import ContentSchema
+from tracim_backend.views.core_api.schemas import CommentSchema
+from tracim_backend.views.core_api.schemas import FileContentSchema
 from tracim_backend.views.core_api.schemas import EventSchema
+from tracim_backend.views.core_api.schemas import TextBasedContentSchema
 from tracim_backend.views.core_api.schemas import UserSchema
 from tracim_backend.views.core_api.schemas import WorkspaceSchema
 
@@ -75,7 +82,13 @@ class EventBuilder:
 
     _user_schema = UserSchema()
     _workspace_schema = WorkspaceSchema()
-    _content_schema = ContentSchema()
+    _content_schemas = {
+        COMMENT_TYPE: CommentSchema(),
+        HTML_DOCUMENTS_TYPE: TextBasedContentSchema(),
+        FILE_TYPE: FileContentSchema(),
+        FOLDER_TYPE: TextBasedContentSchema(),
+        THREAD_TYPE: TextBasedContentSchema(),
+    }
     _event_schema = EventSchema()
 
     def __init__(self, config: CFG) -> None:
@@ -169,6 +182,8 @@ class EventBuilder:
     ) -> None:
         content_api = ContentApi(db_session, self._current_user, self._config)
         content_in_context = content_api.get_content_in_context(content)
+        content_dict = self._content_schemas[content.type].dump(content_in_context).data
+
         workspace_api = WorkspaceApi(db_session, self._current_user, self._config)
         workspace_in_context = workspace_api.get_workspace_with_context(
             workspace_api.get_one(content_in_context.workspace_id)
@@ -178,10 +193,15 @@ class EventBuilder:
             _AUTHOR_FIELD: self._user_schema.dump(
                 user_api.get_user_with_context(self._current_user)
             ).data,
-            _CONTENT_FIELD: self._content_schema.dump(content_in_context).data,
+            _CONTENT_FIELD: content_dict,
             _WORKSPACE_FIELD: self._workspace_schema.dump(workspace_in_context).data,
         }
-        event = Event(entity_type=EntityType.CONTENT, operation=operation, fields=fields)
+        event = Event(
+            entity_type=EntityType.CONTENT,
+            operation=operation,
+            fields=fields,
+            entity_subtype=content.type,
+        )
         db_session.add(event)
 
     # UserRoleInWorkspace events

--- a/backend/tracim_backend/migration/versions/a074395d3caf_add_subtype_in_events_table.py
+++ b/backend/tracim_backend/migration/versions/a074395d3caf_add_subtype_in_events_table.py
@@ -16,7 +16,7 @@ down_revision = "3c92f57c52b2"
 
 def upgrade():
     with op.batch_alter_table("events") as batch_op:
-        batch_op.add_column(sa.Column("entity_subtype", sa.String(), nullable=True))
+        batch_op.add_column(sa.Column("entity_subtype", sa.String(length=100), nullable=True))
     # NOTE SG 2020-05-26: subtype values are left to NULL as we do not have any production
     # database running with the events table.
 

--- a/backend/tracim_backend/migration/versions/a074395d3caf_add_subtype_in_events_table.py
+++ b/backend/tracim_backend/migration/versions/a074395d3caf_add_subtype_in_events_table.py
@@ -1,0 +1,26 @@
+"""add subtype in events table
+
+Revision ID: a074395d3caf
+Revises: 3c92f57c52b2
+Create Date: 2020-05-26 11:30:36.254925
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "a074395d3caf"
+down_revision = "3c92f57c52b2"
+
+
+def upgrade():
+    with op.batch_alter_table("events") as batch_op:
+        batch_op.add_column(sa.Column("entity_subtype", sa.String(), nullable=True))
+    # NOTE SG 2020-05-26: subtype values are left to NULL as we do not have any production
+    # database running with the events table.
+
+
+def downgrade():
+    with op.batch_alter_table("events") as batch_op:
+        batch_op.drop_column("entity_subtype")

--- a/backend/tracim_backend/models/event.py
+++ b/backend/tracim_backend/models/event.py
@@ -13,6 +13,7 @@ from sqlalchemy.types import JSON
 from sqlalchemy.types import DateTime
 from sqlalchemy.types import Enum
 from sqlalchemy.types import Integer
+from sqlalchemy.types import String
 
 from tracim_backend.models.auth import User
 from tracim_backend.models.meta import DeclarativeBase
@@ -69,6 +70,7 @@ class Event(DeclarativeBase):
     event_id = Column(Integer, autoincrement=True, primary_key=True)
     operation = Column(Enum(OperationType), nullable=False)
     entity_type = Column(Enum(EntityType), nullable=False)
+    entity_subtype = Column(String, nullable=True, default=None)
     created = Column(DateTime, nullable=False, default=datetime.utcnow)
     fields = Column(JSON, nullable=False)
 
@@ -81,7 +83,10 @@ class Event(DeclarativeBase):
 
     @property
     def event_type(self) -> str:
-        return "{}.{}".format(self.entity_type.value, self.operation.value)
+        type_ = "{}.{}".format(self.entity_type.value, self.operation.value)
+        if self.entity_subtype:
+            type_ = "{}.{}".format(type_, self.entity_subtype)
+        return type_
 
     def __repr__(self):
         return "<Event(event_id=%s, type=%s, created_date=%s, fields=%s)>" % (

--- a/backend/tracim_backend/models/event.py
+++ b/backend/tracim_backend/models/event.py
@@ -70,7 +70,7 @@ class Event(DeclarativeBase):
     event_id = Column(Integer, autoincrement=True, primary_key=True)
     operation = Column(Enum(OperationType), nullable=False)
     entity_type = Column(Enum(EntityType), nullable=False)
-    entity_subtype = Column(String, nullable=True, default=None)
+    entity_subtype = Column(String(length=100), nullable=True, default=None)
     created = Column(DateTime, nullable=False, default=datetime.utcnow)
     fields = Column(JSON, nullable=False)
 

--- a/backend/tracim_backend/models/event.py
+++ b/backend/tracim_backend/models/event.py
@@ -65,12 +65,13 @@ class Event(DeclarativeBase):
     Event definition.
     """
 
+    ENTITY_SUBTYPE_LENGTH = 100
     __tablename__ = "events"
 
     event_id = Column(Integer, autoincrement=True, primary_key=True)
     operation = Column(Enum(OperationType), nullable=False)
     entity_type = Column(Enum(EntityType), nullable=False)
-    entity_subtype = Column(String(length=100), nullable=True, default=None)
+    entity_subtype = Column(String(length=ENTITY_SUBTYPE_LENGTH), nullable=True, default=None)
     created = Column(DateTime, nullable=False, default=datetime.utcnow)
     fields = Column(JSON, nullable=False)
 

--- a/backend/tracim_backend/tests/functional/test_comments.py
+++ b/backend/tracim_backend/tests/functional/test_comments.py
@@ -70,6 +70,7 @@ class TestCommentsEndpoint(object):
         web_testapp,
         admin_user,
         content_type_list,
+        event_helper,
     ) -> None:
         """
         Get alls comments of a content
@@ -111,6 +112,14 @@ class TestCommentsEndpoint(object):
         assert comment["author"]["public_name"] == admin_user.display_name
         # TODO - G.M - 2018-06-179 - better check for datetime
         assert comment["created"]
+
+        created = event_helper.last_event
+        assert created.event_type == "content.created.comment"
+        assert created.content == comment
+        workspace = web_testapp.get(
+            "/api/v2/workspaces/{}".format(business_workspace.workspace_id), status=200
+        ).json_body
+        assert created.workspace == workspace
 
     def test_api__post_content_comment__err_400__content_not_editable(
         self, workspace_api_factory, content_api_factory, session, web_testapp, content_type_list

--- a/backend/tracim_backend/tests/functional/test_contents.py
+++ b/backend/tracim_backend/tests/functional/test_contents.py
@@ -281,7 +281,12 @@ class TestFolder(object):
         assert res.json_body["code"] == ErrorCode.GENERIC_SCHEMA_VALIDATION_ERROR
 
     def test_api__update_folder__ok_200__nominal_case(
-        self, workspace_api_factory, content_api_factory, web_testapp, content_type_list
+        self,
+        workspace_api_factory,
+        content_api_factory,
+        web_testapp,
+        content_type_list,
+        event_helper,
     ) -> None:
         """
         Update(put) one html document of a content
@@ -335,6 +340,14 @@ class TestFolder(object):
         assert content["last_modifier"] == content["author"]
         assert content["raw_content"] == "<p> Le nouveau contenu </p>"
         assert content["sub_content_types"] == [content_type_list.Folder.slug]
+
+        modified_event = event_helper.last_event
+        assert modified_event.event_type == "content.modified.folder"
+        assert modified_event.content == content
+        workspace = web_testapp.get(
+            "/api/v2/workspaces/{}".format(test_workspace.workspace_id), status=200
+        ).json_body
+        assert modified_event.workspace == workspace
 
     def test_api__update_folder__err_400__not_modified(
         self, workspace_api_factory, content_api_factory, web_testapp, content_type_list
@@ -1040,7 +1053,9 @@ class TestHtmlDocuments(object):
         assert "code" in res.json_body
         assert res.json_body["code"] == ErrorCode.GENERIC_SCHEMA_VALIDATION_ERROR
 
-    def test_api__update_html_document__ok_200__nominal_case(self, web_testapp) -> None:
+    def test_api__update_html_document__ok_200__nominal_case(
+        self, web_testapp, event_helper
+    ) -> None:
         """
         Update(put) one html document of a content
         """
@@ -1099,6 +1114,12 @@ class TestHtmlDocuments(object):
         assert content["last_modifier"] == content["author"]
         assert content["raw_content"] == "<p> Le nouveau contenu </p>"
         assert content["file_extension"] == ".document.html"
+
+        modified_event = event_helper.last_event
+        assert modified_event.event_type == "content.modified.html-document"
+        assert modified_event.content == content
+        workspace = web_testapp.get("/api/v2/workspaces/2", status=200).json_body
+        assert modified_event.workspace == workspace
 
     def test_api__update_html_document__err_400__not_editable(self, web_testapp) -> None:
         """
@@ -2267,7 +2288,7 @@ class TestFiles(object):
         assert res["slug"] == "test-image"
         # A creation is in fact two events: created + modified to add the revision
         (created_event, modified_event) = event_helper.last_events(2)
-        assert created_event.event_type == "content.created"
+        assert created_event.event_type == "content.created.file"
         author = web_testapp.get("/api/v2/users/1", status=200).json_body
         assert created_event.author == author
         workspace = web_testapp.get(
@@ -2275,20 +2296,11 @@ class TestFiles(object):
         ).json_body
         assert created_event.workspace == workspace
 
-        assert modified_event.event_type == "content.modified"
+        assert modified_event.event_type == "content.modified.file"
         content = web_testapp.get(
             "/api/v2/workspaces/{}/files/{}".format(business_workspace.workspace_id, content_id),
             status=200,
         ).json_body
-        for attr in (
-            "has_jpeg_preview",
-            "has_pdf_preview",
-            "mimetype",
-            "page_nb",
-            "raw_content",
-            "size",
-        ):
-            del content[attr]
 
         # NOTE S.G 2020-05-12: allow a small difference in modified time
         # as tests with MySQL sometimes fails with a strict equality
@@ -2311,28 +2323,20 @@ class TestFiles(object):
 
         assert modified_event.workspace == workspace
 
-        res = web_testapp.get(
-            "/api/v2/workspaces/{workspace_id}/files/{content_id}".format(
-                workspace_id=business_workspace.workspace_id, content_id=content_id
-            ),
-            status=200,
-        )
-
-        res = res.json_body
-        assert res["parent_id"] is None
-        assert res["content_type"] == "file"
-        assert res["is_archived"] is False
-        assert res["is_deleted"] is False
-        assert res["is_editable"] is True
-        assert res["content_namespace"] == "content"
-        assert res["workspace_id"] == business_workspace.workspace_id
-        assert isinstance(res["content_id"], int)
-        assert res["status"] == "open"
-        assert res["label"] == "test_image"
-        assert res["slug"] == "test-image"
-        assert res["author"]["user_id"] == admin_user.user_id
-        assert res["page_nb"] == 1
-        assert res["mimetype"] == "image/png"
+        assert content["parent_id"] is None
+        assert content["content_type"] == "file"
+        assert content["is_archived"] is False
+        assert content["is_deleted"] is False
+        assert content["is_editable"] is True
+        assert content["content_namespace"] == "content"
+        assert content["workspace_id"] == business_workspace.workspace_id
+        assert isinstance(content["content_id"], int)
+        assert content["status"] == "open"
+        assert content["label"] == "test_image"
+        assert content["slug"] == "test-image"
+        assert content["author"]["user_id"] == admin_user.user_id
+        assert content["page_nb"] == 1
+        assert content["mimetype"] == "image/png"
 
     def test_api__create_file__err_400__filename_already_used(
         self, workspace_api_factory, content_api_factory, session, web_testapp
@@ -2555,7 +2559,7 @@ class TestFiles(object):
             "/api/v2/workspaces/1/files/{}".format(content_id), status=200
         ).json_body
         last_event = event_helper.last_event
-        assert last_event.event_type == "content.modified"
+        assert last_event.event_type == "content.modified.file"
         assert last_event.content["actives_shares"] == res["actives_shares"]
         assert last_event.content["content_id"] == content_id
         assert last_event.content["content_namespace"] == res["content_namespace"]
@@ -3946,7 +3950,7 @@ class TestThreads(object):
         assert "code" in res.json_body
         assert res.json_body["code"] == ErrorCode.CONTENT_INVALID_ID
 
-    def test_api__update_thread__ok_200__nominal_case(self, web_testapp) -> None:
+    def test_api__update_thread__ok_200__nominal_case(self, web_testapp, event_helper) -> None:
         """
         Update(put) thread
         """
@@ -4005,6 +4009,12 @@ class TestThreads(object):
         assert content["raw_content"] == "<p> Le nouveau contenu </p>"
         assert content["file_extension"] == ".thread.html"
         assert content["filename"] == "My New label.thread.html"
+
+        modified_event = event_helper.last_event
+        assert modified_event.event_type == "content.modified.thread"
+        assert modified_event.content == content
+        workspace = web_testapp.get("/api/v2/workspaces/2", status=200).json_body
+        assert modified_event.workspace == workspace
 
     def test_api__update_thread__err_400__not_modified(self, web_testapp) -> None:
         """

--- a/backend/tracim_backend/tests/functional/test_contents.py
+++ b/backend/tracim_backend/tests/functional/test_contents.py
@@ -4012,7 +4012,24 @@ class TestThreads(object):
 
         modified_event = event_helper.last_event
         assert modified_event.event_type == "content.modified.thread"
-        assert modified_event.content == content
+        # NOTE S.G 2020-05-12: allow a small difference in modified time
+        # as tests with MySQL sometimes fails with a strict equality
+        event_content_modified = dateutil.parser.isoparse(modified_event.content["modified"])
+        content_modified = dateutil.parser.isoparse(content["modified"])
+        modified_diff = (event_content_modified - content_modified).total_seconds()
+        assert abs(modified_diff) < 2
+        assert modified_event.content["file_extension"] == content["file_extension"]
+        assert modified_event.content["filename"] == content["filename"]
+        assert modified_event.content["is_archived"] == content["is_archived"]
+        assert modified_event.content["is_editable"] == content["is_editable"]
+        assert modified_event.content["is_deleted"] == content["is_deleted"]
+        assert modified_event.content["label"] == content["label"]
+        assert modified_event.content["parent_id"] == content["parent_id"]
+        assert modified_event.content["show_in_ui"] == content["show_in_ui"]
+        assert modified_event.content["slug"] == content["slug"]
+        assert modified_event.content["status"] == content["status"]
+        assert modified_event.content["sub_content_types"] == content["sub_content_types"]
+        assert modified_event.content["workspace_id"] == content["workspace_id"]
         workspace = web_testapp.get("/api/v2/workspaces/2", status=200).json_body
         assert modified_event.workspace == workspace
 

--- a/backend/tracim_backend/tests/functional/test_contents.py
+++ b/backend/tracim_backend/tests/functional/test_contents.py
@@ -1117,7 +1117,24 @@ class TestHtmlDocuments(object):
 
         modified_event = event_helper.last_event
         assert modified_event.event_type == "content.modified.html-document"
-        assert modified_event.content == content
+        # NOTE S.G 2020-05-12: allow a small difference in modified time
+        # as tests with MySQL sometimes fails with a strict equality
+        event_content_modified = dateutil.parser.isoparse(modified_event.content["modified"])
+        content_modified = dateutil.parser.isoparse(content["modified"])
+        modified_diff = (event_content_modified - content_modified).total_seconds()
+        assert abs(modified_diff) < 2
+        assert modified_event.content["file_extension"] == content["file_extension"]
+        assert modified_event.content["filename"] == content["filename"]
+        assert modified_event.content["is_archived"] == content["is_archived"]
+        assert modified_event.content["is_editable"] == content["is_editable"]
+        assert modified_event.content["is_deleted"] == content["is_deleted"]
+        assert modified_event.content["label"] == content["label"]
+        assert modified_event.content["parent_id"] == content["parent_id"]
+        assert modified_event.content["show_in_ui"] == content["show_in_ui"]
+        assert modified_event.content["slug"] == content["slug"]
+        assert modified_event.content["status"] == content["status"]
+        assert modified_event.content["sub_content_types"] == content["sub_content_types"]
+        assert modified_event.content["workspace_id"] == content["workspace_id"]
         workspace = web_testapp.get("/api/v2/workspaces/2", status=200).json_body
         assert modified_event.workspace == workspace
 

--- a/backend/tracim_backend/views/core_api/schemas.py
+++ b/backend/tracim_backend/views/core_api/schemas.py
@@ -1234,6 +1234,7 @@ class CollaborativeDocumentEditionConfigSchema(marshmallow.Schema):
 class CommentSchema(marshmallow.Schema):
     content_id = marshmallow.fields.Int(example=6, validate=strictly_positive_int_validator)
     parent_id = marshmallow.fields.Int(example=34, validate=positive_int_validator)
+    content_type = StrippedString(example="html-document", validate=all_content_types_validator)
     raw_content = StrippedString(example="<p>This is just an html comment !</p>")
     author = marshmallow.fields.Nested(UserDigestSchema)
     created = marshmallow.fields.DateTime(

--- a/backend/tracim_backend/views/core_api/schemas.py
+++ b/backend/tracim_backend/views/core_api/schemas.py
@@ -1102,6 +1102,9 @@ class ContentDigestSchema(marshmallow.Schema):
     content_namespace = marshmallow.fields.String(example="content")
     content_id = marshmallow.fields.Int(example=6, validate=strictly_positive_int_validator)
     current_revision_id = marshmallow.fields.Int(example=12)
+    current_revision_type = StrippedString(
+        example=ActionDescription.CREATION, validate=action_description_validator
+    )
     slug = StrippedString(example="intervention-report-12")
     parent_id = marshmallow.fields.Int(
         example=34, allow_none=True, default=None, validate=positive_int_validator


### PR DESCRIPTION
Adds an optional sub-type for events. This sub-type is used in content events to indicate the content's type.

Refs #3095.

## Checkpoints

The goal of this section is to help code reviewers and the merge request author to do the required checks on this pull request. Please don't edit this list.
If one or more of these checkpoints are out of scope, please write below why they are.

**For code reviewers**

- [x] The code is clear enough
- [x] If there are FIXMEs in the code, then there are associated issues and issue is referenced in the FIXME
- [x] If there are TODOs, NOTEs or HACKs in code, the date and the developer initials are present
- [x] Automated tests have been written (covering the feature or non regression), or *at least* an issue has been created to implement the test

**For developers**

- [x] Manual tests done to ensure stability on whole application layers, issue expectation follow
- [x] The original issue has been updated with a short summary of the implemented solution

**For the quality team**

- [x] Tested by the quality team
