### PR TITLE
fix(backend): ensure cookie expiry date is extended when too old

### DIFF
--- a/backend/tests_configs.ini
+++ b/backend/tests_configs.ini
@@ -462,21 +462,6 @@ website.base_url = http://localhost:6543
 user.reset_password.token_lifetime = 5
 frontend.serve = True
 
-[functional_test_with_cookie_realtime]
-app.enabled = contents/thread,contents/file,contents/html-document,contents/folder,upload_permission,share_content
-api.key = mysuperapikey
-preview.jpg.restricted_dims = True
-email.notification.activated = false
-website.base_url = http://localhost:6543
-session.key = session_key
-session.secret = mysecret
-session.type = memory
-session.save_accessed_time = True
-session.cookie_expires = 1
-session.timeout = 1
-session.cookie_on_exception = true
-user.reset_password.token_lifetime = 5
-
 [functional_test_with_cookie_auth]
 app.enabled = contents/thread,contents/file,contents/html-document,contents/folder,upload_permission,share_content
 api.key = mysuperapikey

--- a/backend/tracim_backend/tests/functional/test_session.py
+++ b/backend/tracim_backend/tests/functional/test_session.py
@@ -765,47 +765,6 @@ class TestWhoamiEndpointWithRemoteHeader(object):
 
 @pytest.mark.usefixtures("base_fixture")
 @pytest.mark.parametrize(
-    "config_section", [{"name": "functional_test_with_cookie_realtime"}], indirect=True
-)
-class TestSessionEndpointWithCookieAuthTokenRealtime(object):
-    def test_api__test_cookie_auth_token__ok__renew(self, web_testapp):
-        params = {"email": "admin@admin.admin", "password": "admin@admin.admin"}
-        res = web_testapp.post_json("/api/auth/login", params=params, status=200)
-        assert "Set-Cookie" in res.headers
-        assert "session_key" in web_testapp.cookies
-        user_session_key = web_testapp.cookies["session_key"]
-        sleep(0.3)
-        res = web_testapp.get("/api/auth/whoami", status=200)
-        assert "Set-Cookie" not in res.headers
-        assert "session_key" in web_testapp.cookies
-        assert web_testapp.cookies["session_key"] == user_session_key
-        sleep(0.3)
-        res = web_testapp.get("/api/auth/whoami", status=200)
-        assert "Set-Cookie" not in res.headers
-        assert "session_key" in web_testapp.cookies
-        assert web_testapp.cookies["session_key"] == user_session_key
-        sleep(0.3)
-        res = web_testapp.get("/api/auth/whoami", status=200)
-        assert "Set-Cookie" not in res.headers
-        assert "session_key" in web_testapp.cookies
-        assert web_testapp.cookies["session_key"] == user_session_key
-        sleep(0.3)
-        res = web_testapp.get("/api/auth/whoami", status=200)
-        assert "Set-Cookie" not in res.headers
-        assert "session_key" in web_testapp.cookies
-        assert web_testapp.cookies["session_key"] == user_session_key
-        sleep(0.3)
-        res = web_testapp.get("/api/auth/whoami", status=200)
-        assert "Set-Cookie" not in res.headers
-        assert "session_key" in web_testapp.cookies
-        assert web_testapp.cookies["session_key"] == user_session_key
-        sleep(1)
-        res = web_testapp.get("/api/auth/whoami", params=params, status=401)
-        assert "Set-Cookie" in res.headers
-
-
-@pytest.mark.usefixtures("base_fixture")
-@pytest.mark.parametrize(
     "config_section", [{"name": "functional_test_with_cookie_auth"}], indirect=True
 )
 class TestSessionEndpointWithCookieAuthToken(object):
@@ -897,6 +856,30 @@ class TestSessionEndpointWithCookieAuthToken(object):
             assert res.json_body["code"] is None
             assert "message" in res.json.keys()
             assert "details" in res.json.keys()
+
+    def test_api__test_cookie_auth_token__ok__renew(self, web_testapp):
+        params = {"email": "admin@admin.admin", "password": "admin@admin.admin"}
+        with freeze_time() as frozen_time:
+            res = web_testapp.post_json("/api/auth/login", params=params, status=200)
+            # The cookie is set after login
+            assert "Set-Cookie" in res.headers
+            assert "session_key" in web_testapp.cookies
+            user_session_key = web_testapp.cookies["session_key"]
+            # further requests do not set cookie again
+            res = web_testapp.get("/api/auth/whoami", status=200)
+            assert "Set-Cookie" not in res.headers
+            assert "session_key" in web_testapp.cookies
+            assert web_testapp.cookies["session_key"] == user_session_key
+            # until its age is more than 50% of its max
+            for _ in range(2):
+                # print(_)
+                frozen_time.tick(datetime.timedelta(seconds=350))
+                res = web_testapp.get("/api/auth/whoami", status=200)
+                assert "Set-Cookie" in res.headers
+                assert "session_key" in web_testapp.cookies
+                assert web_testapp.cookies["session_key"] == user_session_key
+            # session timeout is updated when accessed so it is still valid
+            res = web_testapp.get("/api/auth/whoami", status=200)
 
 
 @pytest.mark.usefixtures("base_fixture")


### PR DESCRIPTION
See #3431 

## Checkpoints

These points must be checked before merging. Please don't edit them out.

**For developers**

- [x] If relevant, manual tests have been done to ensure the stability of the whole application and that the involved feature works
- [x] The original issue is up to date w.r.t the latest discussions and contains a short summary of the implemented solution
- [x] Automated tests covering the feature or the fix, have been written, deemed irrelevant (give the reason), or an issue has been created to implement the test (give the link)


**For code reviewers**

- [x] The code is clear enough
- [x] If there are FIXMEs in the code, related issues are mentioned in the FIXME
- [x] If there are TODOs, NOTEs or HACKs in code, the date and the developer initials are present

**For testers**

- [x] Manual, quality tests have been done

Testing method: start the backend with a small cookie expiry date in `development.ini` (`session.cookie_expires = 30` for example). Then play with Tracim and check in the dev toobar that the cookie expiry date is extended properly.
