### PR TITLE
Fix/3567 toolbar height in tinymce

### DIFF
--- a/frontend/src/css/Generic.styl
+++ b/frontend/src/css/Generic.styl
@@ -45,7 +45,7 @@ div.mce-fullscreen
 // INFO - GM - 2020/03/20 - Custom css to make TinyMCE fill its 100% height container
 // Solution inspired originally by these answer: https://stackoverflow.com/questions/19861838/tinymce-4-and-100-height-within-containing-element?answertab=votes#tab-top
 /*Editing container*/
-.mce-tinymce:not(.mce-fullscreen), .mce-container-body
+#content .mce-tinymce:not(.mce-fullscreen), #content .mce-container-body
   min-height 100%
 .mce-container-body.mce-stack-layout
   height 100%

--- a/frontend/src/css/Generic.styl
+++ b/frontend/src/css/Generic.styl
@@ -43,7 +43,7 @@ div.mce-fullscreen
   &.mce-container
     top 61px
 // INFO - GM - 2020/03/20 - Custom css to make TinyMCE fill its 100% height container
-// Solution inspired originally by these answer: https://stackoverflow.com/questions/19861838/tinymce-4-and-100-height-within-containing-element?answertab=votes#tab-top
+// Solution inspired originally by these answers: https://stackoverflow.com/questions/19861838/tinymce-4-and-100-height-within-containing-element?answertab=votes#tab-top
 /*Editing container*/
 #content .mce-tinymce:not(.mce-fullscreen), #content .mce-container-body
   min-height 100%


### PR DESCRIPTION
#3567

This restricts the hack to set the tinymce height to things that are in the `#content` div, so it does not apply to tinymce's toolbars, that are added to the `<body>` tag.

## Checkpoints

<!-- These points must be checked before merging. Please don't edit them out. -->

**For developers**

- [X] If relevant, manual tests have been done to ensure the stability of the whole application and that the involved feature works
- [X] The original issue is up to date w.r.t the latest discussions and contains a short summary of the implemented solution
- [X] Automated tests NOT DONE


**For code reviewers**

- [x] The code is clear enough
- [x] If there are FIXMEs in the code, related issues are mentioned in the FIXME
- [x] If there are TODOs, NOTEs or HACKs in code, the date and the developer initials are present

**For testers**

- [x] Manual, quality tests have been done
