### PR TITLE
Fix/3748 request access button changing by itself

### DIFF
--- a/frontend/src/container/ReduxTlmDispatcher.jsx
+++ b/frontend/src/container/ReduxTlmDispatcher.jsx
@@ -214,17 +214,26 @@ export class ReduxTlmDispatcher extends React.Component {
   }
 
   handleWorkspaceSubscriptionCreated = data => {
-    this.props.dispatch(addWorkspaceSubscription(data.fields.subscription))
+    const { props } = this
+    if (data.fields.user.user_id === props.user.userId) {
+      props.dispatch(addWorkspaceSubscription(data.fields.subscription))
+    }
     this.handleNotification(data)
   }
 
   handleWorkspaceSubscriptionDeleted = data => {
-    this.props.dispatch(removeWorkspaceSubscription(data.fields.subscription))
+    const { props } = this
+    if (data.fields.user.user_id === props.user.userId) {
+      props.dispatch(removeWorkspaceSubscription(data.fields.subscription))
+    }
     this.handleNotification(data)
   }
 
   handleWorkspaceSubscriptionModified = data => {
-    this.props.dispatch(updateWorkspaceSubscription(data.fields.subscription))
+    const { props } = this
+    if (data.fields.user.user_id === props.user.userId) {
+      props.dispatch(updateWorkspaceSubscription(data.fields.subscription))
+    }
     this.handleNotification(data)
   }
 

--- a/frontend/test/src/component/UserSpacesConfig.spec.js
+++ b/frontend/test/src/component/UserSpacesConfig.spec.js
@@ -14,7 +14,8 @@ describe('<UserSpacesConfig />', () => {
     userToEditId: 0,
     onChangeSubscriptionNotif: onChangeSubscriptionNotifCallBack,
     system: { config: {} },
-    admin: true
+    admin: true,
+    dispatch: () => {}
   }
 
   const wrapper = mount(<UserSpacesConfigWithoutHOC {...props} t={key => key} />)

--- a/frontend/test/src/container/ReduxTlmDispatcher.spec.js
+++ b/frontend/test/src/container/ReduxTlmDispatcher.spec.js
@@ -30,7 +30,6 @@ describe('<ReduxTlmDispatcher />', () => {
     <ReduxTlmDispatcherWithoutHOC {...props} />
   )
   describe('workspace subscription TLM handlers', () => {
-
     const testCases = [
       {
         handler: wrapper.instance().handleWorkspaceSubscriptionCreated,

--- a/frontend/test/src/container/ReduxTlmDispatcher.spec.js
+++ b/frontend/test/src/container/ReduxTlmDispatcher.spec.js
@@ -19,6 +19,7 @@ const createSubscription = (userId) => {
 }
 
 describe('<ReduxTlmDispatcher />', () => {
+  const myUser = { ...user }
   const props = {
     user: user,
     t: k => k,
@@ -88,7 +89,12 @@ describe('<ReduxTlmDispatcher />', () => {
     ]
     for (const testCase of testCases) {
       describe(`"${testCase.eventType}" from user ${testCase.subscription.author.user_id}`, () => {
-        beforeEach(() => props.dispatch.resetHistory())
+        beforeEach(() => {
+          props.dispatch.resetHistory()
+          // NOTE - SG - 2020/10/30 - This is needed as other unit tests mess up with our props
+          // But I do not see why
+          wrapper.setProps({ user: myUser })
+        })
 
         const tlm = {
           event_type: testCase.eventType,

--- a/frontend/test/src/container/ReduxTlmDispatcher.spec.js
+++ b/frontend/test/src/container/ReduxTlmDispatcher.spec.js
@@ -1,0 +1,114 @@
+import React from 'react'
+import { expect } from 'chai'
+import { shallow } from 'enzyme'
+import sinon from 'sinon'
+import { addWorkspaceSubscription, updateWorkspaceSubscription, removeWorkspaceSubscription } from '../../../src/action-creator.sync.js'
+import { ReduxTlmDispatcher as ReduxTlmDispatcherWithoutHOC } from '../../../src/container/ReduxTlmDispatcher.jsx'
+import { user } from '../../hocMock/redux/user/user'
+
+const createSubscription = (userId) => {
+  return {
+    state: 'pending',
+    workspace: {
+      workspace_id: 1
+    },
+    author: {
+      user_id: userId
+    }
+  }
+}
+
+describe('<ReduxTlmDispatcher />', () => {
+  const props = {
+    user: user,
+    t: k => k,
+    registerLiveMessageHandlerList: () => {},
+    dispatch: sinon.spy()
+  }
+
+  const wrapper = shallow(
+    <ReduxTlmDispatcherWithoutHOC {...props} />
+  )
+  describe('workspace subscription TLM handlers', () => {
+
+    const testCases = [
+      {
+        handler: wrapper.instance().handleWorkspaceSubscriptionCreated,
+        name: 'handleWorkspaceSubscriptionCreated',
+        description: 'call the addWorkspaceSubscription action',
+        eventType: 'workspace_subscription.created',
+        subscription: createSubscription(1),
+        action: addWorkspaceSubscription,
+        expectedCalled: true
+      },
+      {
+        handler: wrapper.instance().handleWorkspaceSubscriptionCreated,
+        name: 'handleWorkspaceSubscriptionCreated',
+        description: 'not call the addWorkspaceSubscription action',
+        eventType: 'workspace_subscription.created',
+        subscription: createSubscription(2),
+        action: addWorkspaceSubscription,
+        expectedCalled: false
+      },
+      {
+        handler: wrapper.instance().handleWorkspaceSubscriptionDeleted,
+        name: 'handleWorkspaceSubscriptionDeleted',
+        description: 'call the removeWorkspaceSubscription action',
+        eventType: 'workspace_subscription.deleted',
+        subscription: createSubscription(1),
+        action: removeWorkspaceSubscription,
+        expectedCalled: true
+      },
+      {
+        handler: wrapper.instance().handleWorkspaceSubscriptionDeleted,
+        name: 'handleWorkspaceSubscriptionDeleted',
+        description: 'not call the removeWorkspaceSubscription action',
+        eventType: 'workspace_subscription.deleted',
+        subscription: createSubscription(2),
+        action: removeWorkspaceSubscription,
+        expectedCalled: false
+      },
+      {
+        handler: wrapper.instance().handleWorkspaceSubscriptionModified,
+        name: 'handleWorkspaceSubscriptionModified',
+        description: 'call the updateWorkspaceSubscription reducer',
+        eventType: 'workspace_subscription.modified',
+        subscription: { ...createSubscription(1), createdDate: 'foo' },
+        action: updateWorkspaceSubscription,
+        expectedCalled: true
+      },
+      {
+        handler: wrapper.instance().handleWorkspaceSubscriptionModified,
+        name: 'handleWorkspaceSubscriptionModified',
+        description: 'not call the updateWorkspaceSubscription reducer',
+        eventType: 'workspace_subscription.modified',
+        subscription: { ...createSubscription(2), createdDate: 'foo' },
+        action: updateWorkspaceSubscription,
+        expectedCalled: false
+      }
+    ]
+    for (const testCase of testCases) {
+      describe(`"${testCase.eventType}" from user ${testCase.subscription.author.user_id}`, () => {
+        beforeEach(() => props.dispatch.resetHistory())
+
+        const tlm = {
+          event_type: testCase.eventType,
+          fields: {
+            user: {
+              user_id: testCase.subscription.author.user_id
+            },
+            author: {
+              user_id: testCase.subscription.author.user_id
+            },
+            subscription: testCase.subscription
+          }
+        }
+
+        it(`should ${testCase.description}`, () => {
+          testCase.handler(tlm)
+          expect(!testCase.expectedCalled || props.dispatch.calledOnceWith(testCase.action(testCase.subscription))).to.equal(true)
+        })
+      })
+    }
+  })
+})


### PR DESCRIPTION
Do not modify user workspace subscriptions if subscription TLM comes from another user

See #3748

<!-- Here, you can write a short summary of what the pull request brings. If a related issue exists, please reference it here -->

## Checkpoints

<!-- These points must be checked before merging. Please don't edit them out. -->

**For developers**

- [x] If relevant, manual tests have been done to ensure the stability of the whole application and that the involved feature works
- [x] The original issue is up to date w.r.t the latest discussions and contains a short summary of the implemented solution
- [x] Automated tests covering the feature or the fix, have been written, deemed irrelevant (give the reason), or an issue has been created to implement the test (give the link)


**For code reviewers**

- [x] The code is clear enough
- [x] If there are FIXMEs in the code, related issues are mentioned in the FIXME
- [x] If there are TODOs, NOTEs or HACKs in code, the date and the developer initials are present

**For testers**

- [x] Manual, quality tests have been done
