### PR TITLE
Feat/3799 plugin to remove user from child spaces

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -119,6 +119,8 @@ Stamp current version of database to last (useful for migration):
 
     alembic -c development.ini stamp head
 
+Optional functionalities are available through official plugins, please [read their documentation](official_plugins/README.md) to discover their functionalities and how to activate them.
+
 Running Tracim Backend WSGI APP
 ---------------
 

--- a/backend/official_plugins/README.md
+++ b/backend/official_plugins/README.md
@@ -14,16 +14,16 @@ WARNING: Those plugins are implemented using an experimental API that is planned
 
 This plugin:
 - adds every new user to all OPEN spaces
-- adds all users to every created OPEN space
+- adds all users to every newly created OPEN space
 
 ## Child Removal Plugin (tracim_backend_child_removal)
 
-This plugin recursively removes a user from child spaces when a user is removed from a space.
+When a user is removed from a space, this plugin recursively removes this user from the children of this space.
 
 NOTE: if you activate this plugin we recommend to also activate the Parent Access plugin to get a consistent behavior.
 
 ## Parent Access Plugin (tracim_backend_parent_access)
 
-This plugin recursively adds new members of a space to its parents with default user role of each space.
+This plugin recursively adds new members of a space to its parents with the default user role of each space.
 
 NOTE: if you activate this plugin we recommend to also activate the Child Removal plugin to get a consistent behavior.

--- a/backend/official_plugins/README.md
+++ b/backend/official_plugins/README.md
@@ -1,7 +1,7 @@
 # Official Backend Plugins
 
 This directory contains all official backend plugins.
-You can enable them by by creating a symlink from Tracim plugins folder (`plugin.folder_path` in `development.ini`) to the needed plugin:
+You can enable them by creating a symlink from Tracim plugins folder (`plugin.folder_path` in `development.ini`) to the needed plugin:
 ```shell
 # from backend directory, default configuration
 cd plugins

--- a/backend/official_plugins/README.md
+++ b/backend/official_plugins/README.md
@@ -1,5 +1,29 @@
-## Official Backend Plugins
+# Official Backend Plugins
 
-This directory contains all official backend plugins
-Those plugins are implemented using an experimental API that is planned to change: if you develop your own plugin using this API, expect it to break without notice.
-You can enable them by moving the plugins or creating symlink to plugin you do need in the `plugin.folder_path` directory.
+This directory contains all official backend plugins.
+You can enable them by by creating a symlink from Tracim plugins folder (`plugin.folder_path` in `development.ini`) to the needed plugin:
+```shell
+# from backend directory, default configuration
+cd plugins
+ln -s ../official_plugins/<tracim_backend_plugin_you_need> .
+```
+
+WARNING: Those plugins are implemented using an experimental API that is planned to change: if you develop your own plugins using this API, expect them to break without notice.
+
+## Auto-Invite Plugin (tracim_backend_auto_invite)
+
+This plugin:
+- adds every new user to all OPEN spaces
+- adds all users to every created OPEN space
+
+## Child Removal Plugin (tracim_backend_child_removal)
+
+This plugin recursively removes a user from child spaces when a user is removed from a space.
+
+NOTE: if you activate this plugin we recommend to also activate the Parent Access plugin to get a consistent behavior.
+
+## Parent Access Plugin (tracim_backend_parent_access)
+
+This plugin recursively adds new members of a space to its parents with default user role of each space.
+
+NOTE: if you activate this plugin we recommend to also activate the Child Removal plugin to get a consistent behavior.

--- a/backend/official_plugins/tracim_backend_autoinvite/README.md
+++ b/backend/official_plugins/tracim_backend_autoinvite/README.md
@@ -1,5 +1,0 @@
-# Auto-Invite Plugin
-
-This plugin:
-- adds every new user to all open spaces
-- adds all users to every created open space

--- a/backend/official_plugins/tracim_backend_child_removal/README.md
+++ b/backend/official_plugins/tracim_backend_child_removal/README.md
@@ -1,5 +1,0 @@
-# Child Removal Plugin
-
-This plugin recursively removes a user from child spaces when a user is removed from a parent space.
-
-NOTE: if you activate this plugin, we recommend to also activate the Parent Access plugin to get a consistent behavior.

--- a/backend/official_plugins/tracim_backend_child_removal/README.md
+++ b/backend/official_plugins/tracim_backend_child_removal/README.md
@@ -1,0 +1,5 @@
+# Child Removal Plugin
+
+This plugin recursively removes a user from child spaces when a user is removed from a parent space.
+
+NOTE: if you activate this we recommend to also activate the Parent Access plugin to get a consistent behavior.

--- a/backend/official_plugins/tracim_backend_child_removal/README.md
+++ b/backend/official_plugins/tracim_backend_child_removal/README.md
@@ -2,4 +2,4 @@
 
 This plugin recursively removes a user from child spaces when a user is removed from a parent space.
 
-NOTE: if you activate this we recommend to also activate the Parent Access plugin to get a consistent behavior.
+NOTE: if you activate this plugin, we recommend to also activate the Parent Access plugin to get a consistent behavior.

--- a/backend/official_plugins/tracim_backend_child_removal/__init__.py
+++ b/backend/official_plugins/tracim_backend_child_removal/__init__.py
@@ -1,0 +1,38 @@
+from pluggy import PluginManager
+
+from tracim_backend.exceptions import UserRoleNotFound
+from tracim_backend.lib.core.plugins import hookimpl
+from tracim_backend.lib.core.userworkspace import RoleApi
+from tracim_backend.lib.utils.request import TracimContext
+from tracim_backend.models.data import UserRoleInWorkspace
+
+
+class ChildRemovalPlugin:
+    """
+    This plugin ensures that a user who is removed from a space is also removed from
+    every child/descendant space he is member of.
+    
+    Needs a registration using 'register_tracim_plugin' function.
+    """
+
+    @hookimpl
+    def on_user_role_in_workspace_deleted(
+        self, role: UserRoleInWorkspace, context: TracimContext
+    ) -> None:
+        """
+        Remove the user from all child spaces
+        """
+        user = role.user
+        parent_workspace = role.workspace
+        rapi = RoleApi(session=context.dbsession, config=context.app_config, current_user=None)
+        for workspace in parent_workspace.recursive_children:
+            try:
+                rapi.delete_one(
+                    user_id=user.user_id, workspace_id=workspace.workspace_id, flush=False,
+                )
+            except UserRoleNotFound:
+                pass
+
+
+def register_tracim_plugin(plugin_manager: PluginManager):
+    plugin_manager.register(ChildRemovalPlugin())

--- a/backend/official_plugins/tracim_backend_parent_access/README.md
+++ b/backend/official_plugins/tracim_backend_parent_access/README.md
@@ -1,5 +1,0 @@
-# Parent Access Plugin
-
-This plugin recursively adds new members of space to its parents with default user role of each space.
-
-NOTE: if you activate this plugin, we recommend to also activate the Child Removal plugin to get a consistent behavior.

--- a/backend/official_plugins/tracim_backend_parent_access/README.md
+++ b/backend/official_plugins/tracim_backend_parent_access/README.md
@@ -1,5 +1,5 @@
 # Parent Access Plugin
 
-This plugin:
-- recursively adds new members of space to its parents
-with default user role of each space
+This plugin recursively adds new members of space to its parents with default user role of each space.
+
+NOTE: if you activate this we recommend to also activate the Child Removal plugin to get a consistent behavior.

--- a/backend/official_plugins/tracim_backend_parent_access/README.md
+++ b/backend/official_plugins/tracim_backend_parent_access/README.md
@@ -2,4 +2,4 @@
 
 This plugin recursively adds new members of space to its parents with default user role of each space.
 
-NOTE: if you activate this we recommend to also activate the Child Removal plugin to get a consistent behavior.
+NOTE: if you activate this plugin, we recommend to also activate the Child Removal plugin to get a consistent behavior.

--- a/backend/tracim_backend/lib/core/userworkspace.py
+++ b/backend/tracim_backend/lib/core/userworkspace.py
@@ -44,7 +44,9 @@ class RoleApi(object):
         return self._apply_base_filters(self._session.query(UserRoleInWorkspace))
 
     def get_user_workspaces_ids(self, user_id: int, min_role: int) -> typing.List[int]:
-        assert self._user.profile == Profile.ADMIN or self._user.user_id == user_id
+        assert (
+            not self._user or self._user.profile == Profile.ADMIN or self._user.user_id == user_id
+        )
         workspaces_ids_tuples = (
             self._base_query()
             .with_entities(UserRoleInWorkspace.workspace_id)

--- a/backend/tracim_backend/tests/fixtures.py
+++ b/backend/tracim_backend/tests/fixtures.py
@@ -239,6 +239,13 @@ def load_auto_invite_plugin(test_context, official_plugin_folder):
     return tracim_plugin_loader(plugin_name, pluggy_manager, official_plugin_folder)
 
 
+@pytest.fixture()
+def load_child_removal_plugin(test_context, official_plugin_folder):
+    pluggy_manager = test_context.plugin_manager
+    plugin_name = "tracim_backend_child_removal"
+    return tracim_plugin_loader(plugin_name, pluggy_manager, official_plugin_folder)
+
+
 @pytest.fixture
 def test_context(app_config, session_factory):
     yield TracimTestContext(app_config, session_factory=session_factory)

--- a/backend/tracim_backend/tests/plugins/test_child_removal_plugin.py
+++ b/backend/tracim_backend/tests/plugins/test_child_removal_plugin.py
@@ -1,0 +1,46 @@
+import pytest
+
+from tracim_backend import AuthType
+from tracim_backend.exceptions import UserRoleNotFound
+from tracim_backend.models.roles import WorkspaceRoles
+from tracim_backend.tests.fixtures import *  # noqa:F401,F403
+
+
+@pytest.mark.usefixtures("base_fixture")
+class TestParentAccessPlugin(object):
+    def test__add_new_user_to_parent_workspaces__ok__nominal_case(
+        self,
+        admin_user,
+        session,
+        app_config,
+        workspace_api_factory,
+        role_api_factory,
+        user_api_factory,
+        load_child_removal_plugin,
+    ):
+        """
+        Test if users are correctly removed from descendant workspaces with child_removal enabled
+        """
+        with load_child_removal_plugin:
+            wapi = workspace_api_factory.get()
+            parent_workspace = wapi.create_workspace(
+                label="parent", default_user_role=WorkspaceRoles.READER
+            )
+            child_workspace = wapi.create_workspace(
+                label="child", parent=parent_workspace, default_user_role=WorkspaceRoles.CONTRIBUTOR
+            )
+            grandson_workspace = wapi.create_workspace(
+                label="grandson", parent=child_workspace, default_user_role=WorkspaceRoles.READER
+            )
+            uapi = user_api_factory.get()
+            user_1 = uapi.create_user(
+                email="u.1@u.u", auth_type=AuthType.INTERNAL, do_save=True, do_notify=False
+            )
+            role_api = role_api_factory.get()
+            for workspace in (parent_workspace, child_workspace, grandson_workspace):
+                role_api.create_one(user_1, workspace, WorkspaceRoles.CONTENT_MANAGER.level, False)
+            role_api.delete_one(user_1.user_id, parent_workspace.workspace_id)
+            with pytest.raises(UserRoleNotFound):
+                assert role_api.get_one(user_1.user_id, child_workspace.workspace_id)
+            with pytest.raises(UserRoleNotFound):
+                assert role_api.get_one(user_1.user_id, grandson_workspace.workspace_id)

--- a/backend/tracim_backend/tests/plugins/test_child_removal_plugin.py
+++ b/backend/tracim_backend/tests/plugins/test_child_removal_plugin.py
@@ -2,13 +2,29 @@ import pytest
 
 from tracim_backend import AuthType
 from tracim_backend.exceptions import UserRoleNotFound
+from tracim_backend.lib.core.plugins import hookimpl
+from tracim_backend.lib.core.workspace import WorkspaceApi
+from tracim_backend.lib.core.userworkspace import RoleApi
+from tracim_backend.lib.utils.request import TracimContext
+from tracim_backend.models.data import UserRoleInWorkspace
 from tracim_backend.models.roles import WorkspaceRoles
 from tracim_backend.tests.fixtures import *  # noqa:F401,F403
 
 
+class RemoveFromAllSpacesPlugin:
+    @hookimpl
+    def on_user_role_in_workspace_deleted(
+        self, role: UserRoleInWorkspace, context: TracimContext
+    ) -> None:
+        wapi = WorkspaceApi(context.dbsession, None, context.app_config)
+        rapi = RoleApi(context.dbsession, None, context.app_config)
+        for workspace in wapi.get_all_for_user(role.user):
+            rapi.delete_one(role.user.user_id, workspace.workspace_id, flush=False)
+
+
 @pytest.mark.usefixtures("base_fixture")
-class TestParentAccessPlugin(object):
-    def test__add_new_user_to_parent_workspaces__ok__nominal_case(
+class TestChildRemovalPlugin(object):
+    def test__remove_user_from_descendant_workspaces__ok__nominal_case(
         self,
         admin_user,
         session,
@@ -21,6 +37,45 @@ class TestParentAccessPlugin(object):
         """
         Test if users are correctly removed from descendant workspaces with child_removal enabled
         """
+        with load_child_removal_plugin:
+            wapi = workspace_api_factory.get()
+            parent_workspace = wapi.create_workspace(
+                label="parent", default_user_role=WorkspaceRoles.READER
+            )
+            child_workspace = wapi.create_workspace(
+                label="child", parent=parent_workspace, default_user_role=WorkspaceRoles.CONTRIBUTOR
+            )
+            grandson_workspace = wapi.create_workspace(
+                label="grandson", parent=child_workspace, default_user_role=WorkspaceRoles.READER
+            )
+            uapi = user_api_factory.get()
+            user_1 = uapi.create_user(
+                email="u.1@u.u", auth_type=AuthType.INTERNAL, do_save=True, do_notify=False
+            )
+            role_api = role_api_factory.get()
+            for workspace in (parent_workspace, child_workspace, grandson_workspace):
+                role_api.create_one(user_1, workspace, WorkspaceRoles.CONTENT_MANAGER.level, False)
+            role_api.delete_one(user_1.user_id, parent_workspace.workspace_id)
+            with pytest.raises(UserRoleNotFound):
+                assert role_api.get_one(user_1.user_id, child_workspace.workspace_id)
+            with pytest.raises(UserRoleNotFound):
+                assert role_api.get_one(user_1.user_id, grandson_workspace.workspace_id)
+
+    def test__remove_user_from_descendant_workspaces__ok__also_removed_in_another_plugin(
+        self,
+        admin_user,
+        session,
+        app_config,
+        workspace_api_factory,
+        role_api_factory,
+        user_api_factory,
+        load_child_removal_plugin,
+        test_context,
+    ):
+        """
+        Test if users are correctly removed from descendant workspaces with child_removal enabled
+        """
+        test_context.plugin_manager.register(RemoveFromAllSpacesPlugin())
         with load_child_removal_plugin:
             wapi = workspace_api_factory.get()
             parent_workspace = wapi.create_workspace(


### PR DESCRIPTION
See #3799.

<!-- Here, you can write a short summary of what the pull request brings. If a related issue exists, please reference it here -->

## Checkpoints

<!-- These points must be checked before merging. Please don't edit them out. -->

**For developers**

- [x] If relevant, manual tests have been done to ensure the stability of the whole application and that the involved feature works
- [x] The original issue is up to date w.r.t the latest discussions and contains a short summary of the implemented solution
- [x] Automated tests covering the feature or the fix, have been written, deemed irrelevant (give the reason), or an issue has been created to implement the test (give the link)


**For code reviewers**

- [x] The code is clear enough
- [x] If there are FIXMEs in the code, related issues are mentioned in the FIXME
- [x] If there are TODOs, NOTEs or HACKs in code, the date and the developer initials are present

**For testers**

- [x] Manual, quality tests have been done

**Testing method**
1. Enable the plugin in the backend:
```shell
# from backend folder
```shell
mkdir -p plugins
cd plugins
ln -s ../official_plugins/tracim_backend_child_removal .
```
Then start/restart the backend

2. Create two spaces: one parent and one child
3. Add a user in both spaces
4. Remove the user from the parent space
5. The user should not be member of the child space anymor.
