### PR TITLE
fix(frontend,activity): handle case of a comment message with unavailable parent content

### DIFF
--- a/frontend/src/util/activity.js
+++ b/frontend/src/util/activity.js
@@ -42,7 +42,7 @@ const createContentActivity = async (activityParams, messageList, apiUrl) => {
     ))
     if (response.apiResponse.status === 200) {
       content = response.body
-    }
+    } else return null
   }
 
   const response = await handleFetchResult(await getContentComment(apiUrl, content.workspace_id, content.content_id))
@@ -108,7 +108,8 @@ const createActivityListFromActivityMap = async (activityMap, apiUrl) => {
   for (const { params, list } of activityMap.values()) {
     activityCreationList.push(createActivity(params, list, apiUrl))
   }
-  return await Promise.all(activityCreationList)
+  // NOTE - SG - 2020-11-19 - remove the null activities (can happen with content activities)
+  return (await Promise.all(activityCreationList)).filter(i => i)
 }
 
 /**
@@ -176,7 +177,7 @@ export const addMessageToActivityList = async (message, activityList, apiUrl) =>
   const activityIndex = activityList.findIndex(a => a.id === activityParams.id)
   if (activityIndex === -1) {
     const activity = await createActivity(activityParams, [message], apiUrl)
-    return [activity, ...activityList]
+    return activity ? [activity, ...activityList] : activityList
   }
   const oldActivity = activityList[activityIndex]
   const updatedActivity = updateActivity(message, oldActivity)

--- a/frontend/test/apiMock.js
+++ b/frontend/test/apiMock.js
@@ -213,6 +213,12 @@ const mockGetContent200 = (apiUrl, contentId, content) => {
     .reply(200, content)
 }
 
+const mockGetFileContent400 = (apiUrl, workspaceId, contentId) => {
+  return nock(apiUrl)
+    .get(`/workspaces/${workspaceId}/files/${contentId}`)
+    .reply(400, {})
+}
+
 export {
   mockGetWorkspaceDetail200,
   mockGetWorkspaceMemberList200,
@@ -242,5 +248,6 @@ export {
   mockGetUser200,
   mockGetFolderContentList200,
   mockGetContentComments200,
-  mockGetContent200
+  mockGetContent200,
+  mockGetFileContent400
 }


### PR DESCRIPTION
See #3852 

[skip ci pytest]

<!-- Here, you can write a short summary of what the pull request brings. If a related issue exists, please reference it here -->

## Checkpoints

<!-- These points must be checked before merging. Please don't edit them out. -->

**For developers**

- [x] If relevant, manual tests have been done to ensure the stability of the whole application and that the involved feature works
- [x] The original issue is up to date w.r.t the latest discussions and contains a short summary of the implemented solution
- [x] Automated tests covering the feature or the fix, have been written, deemed irrelevant (give the reason), or an issue has been created to implement the test (give the link)


**For code reviewers**

- [x] The code is clear enough
- [x] If there are FIXMEs in the code, related issues are mentioned in the FIXME
- [x] If there are TODOs, NOTEs or HACKs in code, the date and the developer initials are present

**For testers**

- ~~[ ] Manual, quality tests have been done~~: as reproducing the error in a real situation is difficult I would test it directly on our pre-production (as we have a content triggering this error inside).
