### PR TITLE
feat(backend): add black and isort plugins to flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,14 +11,23 @@ repos:
           - id: debug-statements
           - id: check-merge-conflict
     # backend specific
-    - repo: https://gitlab.com/pycqa/flake8
-      rev: 3.7.9
+    - repo: https://github.com/ambv/black
+      rev: stable
       hooks:
-          - id: flake8
-            name: flake8
+          - id: black
             files: 'backend'
     - repo: https://github.com/asottile/seed-isort-config
       rev: v1.8.0
       hooks:
           - id: seed-isort-config
             args: [--settings-path=backend]
+    - repo: https://github.com/pre-commit/mirrors-isort
+      rev: v4.3.18
+      hooks:
+          - id: isort
+            files: 'backend'
+    - repo: https://gitlab.com/pycqa/flake8
+      rev: 3.7.9
+      hooks:
+          - id: flake8
+            files: 'backend'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,29 +15,10 @@ repos:
       rev: 3.7.9
       hooks:
           - id: flake8
-            files: 'backend/tracim_backend'
-          - id: flake8
-            files: 'backend/official_plugins'
+            name: flake8
+            files: 'backend'
     - repo: https://github.com/asottile/seed-isort-config
       rev: v1.8.0
       hooks:
           - id: seed-isort-config
             args: [--settings-path=backend]
-    - repo: https://github.com/pre-commit/mirrors-isort
-      rev: 'v4.3.18'
-      hooks:
-          - id: isort
-            args: [--settings-path=backend/setup.cfg]
-            files: 'backend/tracim_backend/(.*)/*.py'
-          - id: isort
-            args: [--settings-path=backend/setup.cfg]
-            files: 'backend/official_plugins/(.*)/*.py'
-    - repo: https://github.com/ambv/black
-      rev: stable
-      hooks:
-          - id: black
-            args: [-l 100]
-            files: 'backend/tracim_backend'
-          - id: black
-            args: [-l 100]
-            files: 'backend/official_plugins'

--- a/.travis.yml
+++ b/.travis.yml
@@ -153,26 +153,12 @@ jobs:
 
     # INFO - G.M - 2019-04-25 - Stage: Static tests ###
     - stage: static-tests
-      name: black
-      install:
-        - pip install -r $TRAVIS_BUILD_DIR/backend/requirements-devtool.txt
-      script:
-        - black --version
-        - black -l 100 --exclude '/(\..*)/' --diff --check $TRAVIS_BUILD_DIR/backend/tracim_backend
-    - stage: static-tests
-      name: isort
-      install:
-        - pip install -r $TRAVIS_BUILD_DIR/backend/requirements-devtool.txt
-      script:
-        - echo -n "isort " & isort --version-number
-        - isort -df -c $TRAVIS_BUILD_DIR/backend/tracim_backend/**/*.py
-    - stage: static-tests
       name: flake8
       install:
         - pip install -r $TRAVIS_BUILD_DIR/backend/requirements-devtool.txt
       script:
         - flake8 --version
-        - flake8 $TRAVIS_BUILD_DIR/backend/tracim_backend
+        - flake8 $TRAVIS_BUILD_DIR/backend
 
     # INFO - G.M - 2019-04-25 - Stage: Quick Tests ###
     - stage: quick-tests

--- a/backend/official_plugins/tracim_backend_child_removal/__init__.py
+++ b/backend/official_plugins/tracim_backend_child_removal/__init__.py
@@ -11,7 +11,7 @@ class ChildRemovalPlugin:
     """
     This plugin ensures that a user who is removed from a space is also removed from
     every child/descendant space he is member of.
-    
+
     Needs a registration using 'register_tracim_plugin' function.
     """
 

--- a/backend/requirements-devtool.txt
+++ b/backend/requirements-devtool.txt
@@ -4,3 +4,5 @@ isort==4.3.21
 mypy==0.770
 pre-commit==2.2.0
 black==19.10b0
+flake8-black==0.2.1
+flake8-isort==4.0.0

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -1,5 +1,7 @@
 import sys
-from setuptools import setup, find_packages
+
+from setuptools import find_packages
+from setuptools import setup
 
 requires = [
     # pyramid
@@ -9,12 +11,12 @@ requires = [
     "pyramid_retry",
     "waitress",
     # Database
-    'pyramid_tm',
-    'SQLAlchemy',
-    'transaction',
-    'zope.sqlalchemy',
-    'alembic',
-    'sqlakeyset',
+    "pyramid_tm",
+    "SQLAlchemy",
+    "transaction",
+    "zope.sqlalchemy",
+    "alembic",
+    "sqlakeyset",
     # API
     "hapic[marshmallow]>=0.83",
     # INFO - G.M - 2019-03-21 - this is needed as there is a requirement issue
@@ -129,7 +131,7 @@ setup(
             "webdav = tracim_backend:webdav",
             "caldav = tracim_backend:caldav",
         ],
-        "console_scripts": ["tracimcli = tracim_backend.command:main",],
+        "console_scripts": ["tracimcli = tracim_backend.command:main"],
         "tracimcli": [
             "user_create = tracim_backend.command.user:CreateUserCommand",
             "user_update = tracim_backend.command.user:UpdateUserCommand",
@@ -151,6 +153,6 @@ setup(
         ],
     },
     message_extractors={
-        "tracim_backend": [("**.py", "python", None), ("templates/**.mak", "mako", None),]
+        "tracim_backend": [("**.py", "python", None), ("templates/**.mak", "mako", None)]
     },
 )

--- a/backend/setup_dev_env.py
+++ b/backend/setup_dev_env.py
@@ -7,6 +7,7 @@ Simple script to setup require directories for pytests
 import os
 from pathlib import Path  # python3 only
 from typing import Optional
+
 from dotenv import load_dotenv
 
 env_path = Path(".") / ".test.env"

--- a/backend/tracim_backend/lib/core/application.py
+++ b/backend/tracim_backend/lib/core/application.py
@@ -3,9 +3,9 @@ import typing
 from typing import List
 
 from tracim_backend.app_models.workspace_menu_entries import WorkspaceMenuEntry
+from tracim_backend.app_models.workspace_menu_entries import activity_menu_entry
 from tracim_backend.app_models.workspace_menu_entries import all_content_menu_entry
 from tracim_backend.app_models.workspace_menu_entries import dashboard_menu_entry
-from tracim_backend.app_models.workspace_menu_entries import activity_menu_entry
 from tracim_backend.exceptions import AppDoesNotExist
 from tracim_backend.lib.utils.app import TracimApplication
 from tracim_backend.lib.utils.app import TracimContentType

--- a/backend/tracim_backend/lib/rq/worker.py
+++ b/backend/tracim_backend/lib/rq/worker.py
@@ -8,8 +8,8 @@ import transaction
 
 from tracim_backend.config import CFG
 from tracim_backend.lib.core.plugins import init_plugin_manager
-from tracim_backend.lib.utils.request import TracimContext
 from tracim_backend.lib.utils.daemon import initialize_config_from_environment
+from tracim_backend.lib.utils.request import TracimContext
 from tracim_backend.models.setup_models import create_dbsession_for_context
 from tracim_backend.models.setup_models import get_engine
 from tracim_backend.models.setup_models import get_session_factory

--- a/backend/tracim_backend/migration/versions/5d3331933ef3_add_mention_in_entitytype_enum.py
+++ b/backend/tracim_backend/migration/versions/5d3331933ef3_add_mention_in_entitytype_enum.py
@@ -10,7 +10,6 @@ import typing
 from alembic import op
 import sqlalchemy as sa
 
-
 # revision identifiers, used by Alembic.
 revision = "5d3331933ef3"
 down_revision = "fb2ae8c604ac"

--- a/backend/tracim_backend/migration/versions/a074395d3caf_add_subtype_in_events_table.py
+++ b/backend/tracim_backend/migration/versions/a074395d3caf_add_subtype_in_events_table.py
@@ -8,7 +8,6 @@ Create Date: 2020-05-26 11:30:36.254925
 from alembic import op
 import sqlalchemy as sa
 
-
 # revision identifiers, used by Alembic.
 revision = "a074395d3caf"
 down_revision = "3c92f57c52b2"

--- a/backend/tracim_backend/migration/versions/fb2ae8c604ac_add_undelete_operation_type_in_enum.py
+++ b/backend/tracim_backend/migration/versions/fb2ae8c604ac_add_undelete_operation_type_in_enum.py
@@ -8,7 +8,6 @@ Create Date: 2020-06-23 09:56:58.775491
 from alembic import op
 import sqlalchemy as sa
 
-
 # revision identifiers, used by Alembic.
 revision = "fb2ae8c604ac"
 down_revision = "9d4621f59614"

--- a/backend/tracim_backend/tests/plugins/test_child_removal_plugin.py
+++ b/backend/tracim_backend/tests/plugins/test_child_removal_plugin.py
@@ -3,8 +3,8 @@ import pytest
 from tracim_backend import AuthType
 from tracim_backend.exceptions import UserRoleNotFound
 from tracim_backend.lib.core.plugins import hookimpl
-from tracim_backend.lib.core.workspace import WorkspaceApi
 from tracim_backend.lib.core.userworkspace import RoleApi
+from tracim_backend.lib.core.workspace import WorkspaceApi
 from tracim_backend.lib.utils.request import TracimContext
 from tracim_backend.models.data import UserRoleInWorkspace
 from tracim_backend.models.roles import WorkspaceRoles


### PR DESCRIPTION
This is easier to launch: `flake8` for only checking and also simplifies the CI (only one job for linting).

## Checkpoints

<!-- These points must be checked before merging. Please don't edit them out. -->

**For developers**

- [x] If relevant, manual tests have been done to ensure the stability of the whole application and that the involved feature works
- [x] The original issue is up to date w.r.t the latest discussions and contains a short summary of the implemented solution
- [x] Automated tests covering the feature or the fix, have been written, deemed irrelevant (give the reason), or an issue has been created to implement the test (give the link)


**For code reviewers**

- [x] The code is clear enough
- [x] If there are FIXMEs in the code, related issues are mentioned in the FIXME
- [x] If there are TODOs, NOTEs or HACKs in code, the date and the developer initials are present

**For testers**

- [x] Manual, quality tests have been done
