### PR TITLE
add support for preview_generator cache for non-local storage type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,8 +90,8 @@ _install_backend: &_install_backend
   before_script:
     - docker pull mailhog/mailhog
     - docker run -d -p 1025:1025 -p 8025:8025 mailhog/mailhog
-    - docker pull rroemhild/test-openldap
-    - docker run -d -p 3890:389 rroemhild/test-openldap
+    - docker pull rroemhild/test-openldap:1.1
+    - docker run -d -p 3890:389 rroemhild/test-openldap:1.1
     - cd $TRAVIS_BUILD_DIR/backend
     - docker-compose pull
     - docker-compose up -d minio elasticsearch

--- a/backend/README.md
+++ b/backend/README.md
@@ -347,7 +347,7 @@ See here: https://github.com/rroemhild/docker-test-openldap
 
 You can run it this way with Docker:
 
-    docker pull rroemhild/test-openldap
+    docker pull rroemhild/test-openldap:1.1
     docker run -d -p 3890:389 rroemhild/test-openldap
 
 You need also a elasticsearch server on port 9200 for elasticsearch related test

--- a/backend/tracim_backend/lib/core/content.py
+++ b/backend/tracim_backend/lib/core/content.py
@@ -758,15 +758,15 @@ class ContentApi(object):
         lockfile_path = "{base_path}{file_extension}".format(
             base_path=base_path, file_extension=".lock",
         )
-        # FIXME - G.M - This will create a lockfile for
+        # FIXME - G.M - 2020-01-05 - This will create a lockfile for
         # each depot file we do need (each content revision)
         # This file will NOT been removed at the end on linux (FileLock use flock):
         # see  https://stackoverflow.com/questions/17708885/flock-removing-locked-file-without-race-condition
         # some search need to be made to see if another solution is possible avoiding creating
-        # too much file.
+        # too much file.see https://github.com/tracim/tracim/issues/4014
         with filelock.FileLock(lockfile_path):
             try:
-                # HACK - G.M - This mecanism is inefficient because it
+                # HACK - G.M - 2020-01-05 - This mecanism is inefficient because it
                 # generate a temporary file each time
                 # Improvement need to be made in preview_generator itself.
                 # to handle more properly theses issues

--- a/backend/tracim_backend/lib/core/content.py
+++ b/backend/tracim_backend/lib/core/content.py
@@ -760,20 +760,21 @@ class ContentApi(object):
         )
         # FIXME - G.M - 2020-01-05 - This will create a lockfile for
         # each depot file we do need (each content revision)
-        # This file will NOT been removed at the end on linux (FileLock use flock):
+        # This file will NOT be removed at the end on Linux (FileLock use flock):
         # see  https://stackoverflow.com/questions/17708885/flock-removing-locked-file-without-race-condition
-        # some search need to be made to see if another solution is possible avoiding creating
-        # too much file.see https://github.com/tracim/tracim/issues/4014
+        # some investigation needs to be conducted to see if another solution is possible avoiding creating
+        # too many files.see https://github.com/tracim/tracim/issues/4014
         with filelock.FileLock(lockfile_path):
             try:
-                # HACK - G.M - 2020-01-05 - This mecanism is inefficient because it
-                # generate a temporary file each time
-                # Improvement need to be made in preview_generator itself.
-                # to handle more properly theses issues
+                # HACK - G.M - 2020-01-05 - This mechanism is inefficient because it
+                # generates a temporary file each time
+                # Improvements need to be made in preview_generator itself.
+                # to handle more properly these issues.
                 # We do rely on consistent path based on gettemdir(),
                 # normally /tmp to give consistent path, this is a quick fix which does
-                # not need change in preview-generator.
-                # note: this base path is configurable through env var according to python doc
+                # not need any change in preview-generator.
+                # note: this base path is configurable through an envirnoment var according
+                # to the Python doc:
                 # https://docs.python.org/3/library/tempfile.html#tempfile.gettempdir
                 with open(file_path, "wb",) as tmp:
                     tmp.write(depot_stored_file.read())

--- a/backend/tracim_backend/lib/core/content.py
+++ b/backend/tracim_backend/lib/core/content.py
@@ -763,12 +763,12 @@ class ContentApi(object):
         # This file will NOT be removed at the end on Linux (FileLock use flock):
         # see  https://stackoverflow.com/questions/17708885/flock-removing-locked-file-without-race-condition
         # some investigation needs to be conducted to see if another solution is possible avoiding creating
-        # too many files.see https://github.com/tracim/tracim/issues/4014
+        # too many files. See https://github.com/tracim/tracim/issues/4014
         with filelock.FileLock(lockfile_path):
             try:
                 # HACK - G.M - 2020-01-05 - This mechanism is inefficient because it
                 # generates a temporary file each time
-                # Improvements need to be made in preview_generator itself.
+                # Improvements need to be made in preview_generator itself
                 # to handle more properly these issues.
                 # We do rely on consistent path based on gettemdir(),
                 # normally /tmp to give consistent path, this is a quick fix which does


### PR DESCRIPTION
Introduce preview_generator cache for non-local storage like s3.
related to #4000 
## Checkpoints

<!-- These points must be checked before merging. Please don't edit them out. -->

**For developers**

- [x] If relevant, manual tests have been done to ensure the stability of the whole application and that the involved feature works
- [x] The original issue is up to date w.r.t the latest discussions and contains a short summary of the implemented solution
- [x] Automated tests covering the feature or the fix, have been written, deemed irrelevant (give the reason), or an issue has been created to implement the test (give the link)
- [x] Make sure that:
  - if there are modifications in the Tracim configuration files (eg. `development.ini`), they are documented in `backend/doc/setting.md`
  - any migration process required for existing instances is documented
  - relevant people for these changes are notified

**For code reviewers**

- [x] The code is clear enough
- [x] If there are FIXMEs in the code, related issues are mentioned in the FIXME
- [x] If there are TODOs, NOTEs or HACKs in code, the date and the developer initials are present

**For testers**

- [x] Manual, quality tests have been done

previous PR: https://github.com/tracim/tracim/pull/4005