### PR TITLE
fix(frontend, public-profile): File size limit upgraded to 10MB

### DIFF
--- a/backend/tracim_backend/views/frontend.py
+++ b/backend/tracim_backend/views/frontend.py
@@ -28,9 +28,9 @@ BASE_CSP_DIRECTIVES = (
     # NOTE S.G. - 2020-12-14 - unsafe-inline is needed for tinyMce
     ("style-src", "'unsafe-inline' 'self'"),
     ("connect-src", "'self'"),
-    ("font-src", "data: *"),
-    ("img-src", "data: *"),
-    ("media-src", "data: *"),
+    ("font-src", "data: blob: *"),
+    ("img-src", "data: blob: *"),
+    ("media-src", "data: blob: *"),
     ("object-src", "'none'"),
     ("default-src", "'self'"),
 )

--- a/frontend/src/container/PublicProfile.jsx
+++ b/frontend/src/container/PublicProfile.jsx
@@ -46,7 +46,7 @@ const ALLOWED_IMAGE_MIMETYPES = [
   'image/gif',
   'image/webp'
 ]
-const MAXIMUM_IMAGE_SIZE = 1 * 1024 * 1024 // 1 MByte
+const MAXIMUM_IMAGE_SIZE = 10 * 1024 * 1024 // 10 MBytes
 const POPUP_DISPLAY_STATE = {
   AVATAR: 'AVATAR',
   COVER: 'COVER'
@@ -420,7 +420,7 @@ export class PublicProfile extends React.Component {
               recommendedDimensions={COVER_IMAGE_DIMENSIONS}
             />
           )}
-          
+
           <CoverImage
             displayedUser={state.displayedUser}
             changeEnabled={isPublicProfileEditable}
@@ -429,7 +429,7 @@ export class PublicProfile extends React.Component {
             coverImageName={coverImageName}
             coverImageAlt={coverImageAlt}
           />
-          
+
           <ProfileMainBar
             displayedUser={state.displayedUser}
             breadcrumbsList={props.breadcrumbs}

--- a/frontend_lib/src/component/FileDropzone/FileDropzone.jsx
+++ b/frontend_lib/src/component/FileDropzone/FileDropzone.jsx
@@ -5,6 +5,13 @@ import { translate } from 'react-i18next'
 import { FILE_PREVIEW_STATE } from '../../helper.js'
 
 export const FileDropzone = props => {
+  const isPreviewObjectUrl = props.preview.startsWith('blob:')
+  if (isPreviewObjectUrl) {
+    React.useEffect(() => {
+      console.log(`Revoking object URL ${props.preview}`)
+      URL.revokeObjectURL(props.preview)
+    })
+  }
   return (
     <Dropzone
       onDrop={props.onDrop}

--- a/frontend_lib/src/component/FileDropzone/FileDropzone.jsx
+++ b/frontend_lib/src/component/FileDropzone/FileDropzone.jsx
@@ -6,12 +6,14 @@ import { FILE_PREVIEW_STATE } from '../../helper.js'
 
 export const FileDropzone = props => {
   const isPreviewObjectUrl = props.preview.startsWith('blob:')
-  if (isPreviewObjectUrl) {
-    React.useEffect(() => {
-      console.log(`Revoking object URL ${props.preview}`)
-      URL.revokeObjectURL(props.preview)
-    })
-  }
+  React.useEffect(() => {
+    return () => {
+      if (isPreviewObjectUrl) {
+        console.log(`Revoking object URL ${props.preview}`)
+        URL.revokeObjectURL(props.preview)
+      }
+    }
+  })
   return (
     <Dropzone
       onDrop={props.onDrop}

--- a/frontend_lib/src/container/PopupUploadFile.jsx
+++ b/frontend_lib/src/container/PopupUploadFile.jsx
@@ -21,7 +21,7 @@ import {
 } from '../customEvent.js'
 import PopupProgressUpload from './PopupProgressUpload.jsx'
 
-const MAX_PREVIEW_IMAGE_SIZE = 2000000
+const MAX_PREVIEW_IMAGE_SIZE = 20 * 1024 * 1024 // 20 MBytes
 
 class PopupUploadFile extends React.Component {
   constructor (props) {
@@ -138,20 +138,14 @@ class PopupUploadFile extends React.Component {
   }
 
   loadImage = file => {
-    const reader = new FileReader()
-    reader.readAsDataURL(file)
+    const img = new Image()
+    const blobUrl = URL.createObjectURL(file)
+    img.src = blobUrl
     return new Promise((resolve, reject) => {
-      reader.onload = e => {
-        const img = new Image()
-        img.src = e.target.result
-        img.onerror = () => reject(new Error())
-        img.onload = () => {
-          if (e.total > 0) {
-            resolve(e.target.result)
-          } else reject(new Error())
-        }
+      img.onerror = () => reject(new Error())
+      img.onload = () => {
+        resolve(blobUrl)
       }
-      reader.onerror = () => reject(new Error())
     })
   }
 

--- a/frontend_lib/src/container/PopupUploadFile.jsx
+++ b/frontend_lib/src/container/PopupUploadFile.jsx
@@ -142,7 +142,7 @@ class PopupUploadFile extends React.Component {
     const blobUrl = URL.createObjectURL(file)
     img.src = blobUrl
     return new Promise((resolve, reject) => {
-      img.onerror = () => reject(new Error())
+      img.onerror = () => reject(new Error('Failed to load the image'))
       img.onload = () => {
         resolve(blobUrl)
       }


### PR DESCRIPTION
See #4101

And use blobs for previewing the image in the browser.


<!-- Here, you can write a short summary of what the pull request brings. If a related issue exists, please reference it here -->

## Checkpoints

<!-- These points must be checked before merging. Please don't edit them out. -->

**For developers**

- [x] If relevant, manual tests have been done to ensure the stability of the whole application and that the involved feature works
- [x] The original issue is up to date w.r.t the latest discussions and contains a short summary of the implemented solution
- [x] Automated tests covering the feature or the fix, have been written, deemed irrelevant (give the reason), or an issue has been created to implement the test (give the link): testing the limit would imply to have a big image in the repository (or generate it when testing).
- [x] Make sure that:
  - if there are modifications in the Tracim configuration files (eg. `development.ini`), they are documented in `backend/doc/setting.md`
  - any migration process required for existing instances is documented
  - relevant people for these changes are notified

**For code reviewers**

- [x] The code is clear enough
- [x] If there are FIXMEs in the code, related issues are mentioned in the FIXME
- [x] If there are TODOs, NOTEs or HACKs in code, the date and the developer initials are present

**For testers**

- [x] Manual, quality tests have been done

**Testing method**

Try to upload an image >1MB but <10MB, it should be possible. With an image >10MB the popup should refuse to upload the file.
Check that the preview of the image is properly displayed.