### PR TITLE
moved refresh button to the right [skip ci pytest]

### DIFF
--- a/frontend_app_agenda/src/css/index.styl
+++ b/frontend_app_agenda/src/css/index.styl
@@ -12,11 +12,11 @@
 
 .agendaPage
   &__warningMessage
-    position fixed
+    position absolute
     left 700px
     top 80px
 
 @media (max-width: max-lg)
   .agendaPage
     &__warningMessage
-      top 75px
+      top 20px

--- a/frontend_app_agenda/src/css/index.styl
+++ b/frontend_app_agenda/src/css/index.styl
@@ -13,7 +13,7 @@
 .agendaPage
   &__warningMessage
     position absolute
-    left 700px
+    right 100px
     top 80px
 
 @media (max-width: max-lg)

--- a/frontend_app_agenda/src/css/index.styl
+++ b/frontend_app_agenda/src/css/index.styl
@@ -12,11 +12,11 @@
 
 .agendaPage
   &__warningMessage
-    position absolute
-    left 450px
-    top 110px
+    position fixed
+    left 700px
+    top 80px
 
 @media (max-width: max-lg)
   .agendaPage
     &__warningMessage
-      top 50px
+      top 75px


### PR DESCRIPTION
#3553

Moved the refresh button to the right, next to the title. 

In order to make the refresh button appear on the calendar, edit one of the space's title in another page. 

## Checkpoints

<!-- These points must be checked before merging. Please don't edit them out. -->

**For developers**

- [x] If relevant, manual tests have been done to ensure the stability of the whole application and that the involved feature works
- [x] The original issue is up to date w.r.t the latest discussions and contains a short summary of the implemented solution
- [x] Automated tests covering the feature or the fix, have been written, deemed irrelevant (give the reason), or an issue has been created to implement the test (give the link)
- [x] Make sure that:
  - if there are modifications in the Tracim configuration files (eg. `development.ini`), they are documented in `backend/doc/setting.md`
  - any migration process required for existing instances is documented
  - relevant people for these changes are notified

**For code reviewers**

- [x] The code is clear enough
- [x] If there are FIXMEs in the code, related issues are mentioned in the FIXME
- [x] If there are TODOs, NOTEs or HACKs in code, the date and the developer initials are present

**For testers**

- [x] Manual, quality tests have been done
