### PR TITLE
fix(backend): remove workspace description from events

### DIFF
--- a/backend/tracim_backend/lib/core/event.py
+++ b/backend/tracim_backend/lib/core/event.py
@@ -74,6 +74,7 @@ from tracim_backend.views.core_api.schemas import UserDigestSchema
 from tracim_backend.views.core_api.schemas import WorkspaceMemberDigestSchema
 from tracim_backend.views.core_api.schemas import WorkspaceSchema
 from tracim_backend.views.core_api.schemas import WorkspaceSubscriptionSchema
+from tracim_backend.views.core_api.schemas import WorkspaceWithoutDescriptionSchema
 
 JsonDict = Dict[str, Any]
 
@@ -83,6 +84,7 @@ class EventApi:
 
     user_schema = UserDigestSchema()
     workspace_schema = WorkspaceSchema()
+    workspace_without_description_schema = WorkspaceWithoutDescriptionSchema()
     content_schemas = {
         COMMENT_TYPE: CommentSchema(),
         HTML_DOCUMENTS_TYPE: ContentSchema(),
@@ -548,7 +550,9 @@ class EventBuilder:
         )
         fields = {
             Event.CONTENT_FIELD: content_dict,
-            Event.WORKSPACE_FIELD: EventApi.workspace_schema.dump(workspace_in_context).data,
+            Event.WORKSPACE_FIELD: EventApi.workspace_without_description_schema.dump(
+                workspace_in_context
+            ).data,
         }
         event_api = EventApi(current_user, context.dbsession, self._config)
         event_api.create_event(
@@ -621,7 +625,9 @@ class EventBuilder:
         role_in_context = role_api.get_user_role_workspace_with_context(role)
         fields = {
             Event.USER_FIELD: user_field,
-            Event.WORKSPACE_FIELD: EventApi.workspace_schema.dump(workspace_in_context).data,
+            Event.WORKSPACE_FIELD: EventApi.workspace_without_description_schema.dump(
+                workspace_in_context
+            ).data,
             Event.MEMBER_FIELD: EventApi.workspace_user_role_schema.dump(role_in_context).data,
         }
         event_api = EventApi(current_user, context.dbsession, self._config)
@@ -677,7 +683,9 @@ class EventBuilder:
         user_api = UserApi(current_user, context.dbsession, self._config, show_deleted=True)
         subscription_author_in_context = user_api.get_user_with_context(subscription.author)
         fields = {
-            Event.WORKSPACE_FIELD: EventApi.workspace_schema.dump(workspace_in_context).data,
+            Event.WORKSPACE_FIELD: EventApi.workspace_without_description_schema.dump(
+                workspace_in_context
+            ).data,
             Event.SUBSCRIPTION_FIELD: EventApi.workspace_subscription_schema.dump(
                 subscription
             ).data,
@@ -709,7 +717,9 @@ class EventBuilder:
         user_api = UserApi(current_user, context.dbsession, self._config, show_deleted=True)
         reaction_author_in_context = user_api.get_user_with_context(reaction.author)
         fields = {
-            Event.WORKSPACE_FIELD: EventApi.workspace_schema.dump(workspace_in_context).data,
+            Event.WORKSPACE_FIELD: EventApi.workspace_without_description_schema.dump(
+                workspace_in_context
+            ).data,
             Event.REACTION_FIELD: EventApi.reaction_schema.dump(reaction).data,
             Event.USER_FIELD: EventApi.user_schema.dump(reaction_author_in_context).data,
             Event.CONTENT_FIELD: content_dict,

--- a/backend/tracim_backend/migration/versions/35cfa7c2f8f9_remove_workspace_description_from_non_.py
+++ b/backend/tracim_backend/migration/versions/35cfa7c2f8f9_remove_workspace_description_from_non_.py
@@ -1,0 +1,54 @@
+"""remove workspace description from non workspace events
+
+Revision ID: 35cfa7c2f8f9
+Revises: 1f36b2979f89
+Create Date: 2021-04-30 11:05:02.107826
+
+"""
+import copy
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "35cfa7c2f8f9"
+down_revision = "1f36b2979f89"
+
+
+events = sa.Table(
+    "events",
+    sa.MetaData(),
+    sa.Column("event_id", sa.Integer),
+    sa.Column("fields", sa.JSON),
+    sa.Column(
+        "entity_type",
+        sa.Enum(
+            "USER",
+            "WORKSPACE",
+            "WORKSPACE_MEMBER",
+            "WORKSPACE_SUBSCRIPTION",
+            "CONTENT",
+            "MENTION",
+            "REACTION",
+        ),
+    ),
+)
+
+
+def upgrade():
+    connection = op.get_bind()
+    for event in connection.execute(events.select().where(events.c.entity_type != "WORKSPACE")):
+        try:
+            fields = copy.deepcopy(event.fields)
+            del fields["workspace"]["description"]
+            connection.execute(
+                events.update().where(events.c.event_id == event.event_id).values(fields=fields)
+            )
+        except KeyError:
+            pass
+
+
+def downgrade():
+    # NOTE - SG - 2021-04-30
+    # No downgrade needed (and even possible) as we remove unwanted data.
+    pass

--- a/backend/tracim_backend/tests/functional/test_comments.py
+++ b/backend/tracim_backend/tests/functional/test_comments.py
@@ -177,7 +177,7 @@ class TestCommentsEndpoint(object):
         workspace = web_testapp.get(
             "/api/workspaces/{}".format(business_workspace.workspace_id), status=200
         ).json_body
-        assert created.workspace == workspace
+        assert created.workspace == {k: v for k, v in workspace.items() if k != "description"}
 
     def test_api__post_content_comment__err_400__content_not_editable(
         self, workspace_api_factory, content_api_factory, session, web_testapp, content_type_list

--- a/backend/tracim_backend/tests/functional/test_contents.py
+++ b/backend/tracim_backend/tests/functional/test_contents.py
@@ -355,7 +355,9 @@ class TestFolder(object):
         workspace = web_testapp.get(
             "/api/workspaces/{}".format(test_workspace.workspace_id), status=200
         ).json_body
-        assert modified_event.workspace == workspace
+        assert modified_event.workspace == {
+            k: v for k, v in workspace.items() if k != "description"
+        }
 
     def test_api__update_folder__err_400__not_modified(
         self, workspace_api_factory, content_api_factory, web_testapp, content_type_list
@@ -1215,7 +1217,9 @@ class TestHtmlDocuments(object):
         assert modified_event.content["sub_content_types"] == content["sub_content_types"]
         assert modified_event.content["workspace_id"] == content["workspace_id"]
         workspace = web_testapp.get("/api/workspaces/2", status=200).json_body
-        assert modified_event.workspace == workspace
+        assert modified_event.workspace == {
+            k: v for k, v in workspace.items() if k != "description"
+        }
 
     def test_api__update_html_document__err_400__not_editable(self, web_testapp) -> None:
         """
@@ -2443,7 +2447,7 @@ class TestFiles(object):
         workspace = web_testapp.get(
             "/api/workspaces/{}".format(business_workspace.workspace_id), status=200
         ).json_body
-        assert created_event.workspace == workspace
+        assert created_event.workspace == {k: v for k, v in workspace.items() if k != "description"}
 
         assert modified_event.event_type == "content.modified.file"
         content = web_testapp.get(
@@ -2470,7 +2474,9 @@ class TestFiles(object):
         assert modified_event.content["sub_content_types"] == res["sub_content_types"]
         assert modified_event.content["workspace_id"] == res["workspace_id"]
 
-        assert modified_event.workspace == workspace
+        assert modified_event.workspace == {
+            k: v for k, v in workspace.items() if k != "description"
+        }
 
         assert content["parent_id"] is None
         assert content["content_type"] == "file"
@@ -2848,7 +2854,7 @@ class TestFiles(object):
         author = web_testapp.get("/api/users/1", status=200).json_body
         assert last_event.author == UserDigestSchema().dump(author).data
         workspace = web_testapp.get("/api/workspaces/1", status=200,).json_body
-        assert last_event.workspace == workspace
+        assert last_event.workspace == {k: v for k, v in workspace.items() if k != "description"}
 
         res = web_testapp.get(
             "/api/workspaces/1/files/{}/raw/{}".format(content_id, image.name), status=200
@@ -4364,7 +4370,9 @@ class TestThreads(object):
         assert modified_event.content["sub_content_types"] == content["sub_content_types"]
         assert modified_event.content["workspace_id"] == content["workspace_id"]
         workspace = web_testapp.get("/api/workspaces/2", status=200).json_body
-        assert modified_event.workspace == workspace
+        assert modified_event.workspace == {
+            k: v for k, v in workspace.items() if k != "description"
+        }
 
     def test_api__update_thread__err_400__not_modified(self, web_testapp) -> None:
         """

--- a/backend/tracim_backend/tests/functional/test_reactions.py
+++ b/backend/tracim_backend/tests/functional/test_reactions.py
@@ -169,7 +169,7 @@ class TestReactionsEndpoint(object):
         workspace = web_testapp.get(
             "/api/workspaces/{}".format(test_workspace.workspace_id), status=200
         ).json_body
-        assert last_event.workspace == workspace
+        assert last_event.workspace == {k: v for k, v in workspace.items() if k != "description"}
         assert last_event.reaction["author"] == UserDigestSchema().dump(author).data
         assert last_event.reaction["content_id"] == folder.content_id
         assert last_event.reaction["reaction_id"] == reaction_id
@@ -289,7 +289,7 @@ class TestReactionsEndpoint(object):
         workspace = web_testapp.get(
             "/api/workspaces/{}".format(test_workspace.workspace_id), status=200
         ).json_body
-        assert last_event.workspace == workspace
+        assert last_event.workspace == {k: v for k, v in workspace.items() if k != "description"}
         assert last_event.reaction["author"] == UserDigestSchema().dump(author).data
         assert last_event.reaction["content_id"] == folder.content_id
         assert last_event.reaction["reaction_id"] == reaction_id

--- a/backend/tracim_backend/tests/functional/test_workspace_subscription.py
+++ b/backend/tracim_backend/tests/functional/test_workspace_subscription.py
@@ -152,7 +152,7 @@ class TestUserSubscriptionEndpoint(object):
         workspace = web_testapp.get(
             "/api/workspaces/{}".format(on_request_workspace.workspace_id), status=200
         ).json_body
-        assert last_event.workspace == workspace
+        assert last_event.workspace == {k: v for k, v in workspace.items() if k != "description"}
         assert last_event.subscription["state"] == subscription["state"]
         assert last_event.subscription["workspace"] == subscription["workspace"]
         assert last_event.subscription["author"] == subscription["author"]
@@ -277,7 +277,7 @@ class TestUserSubscriptionEndpoint(object):
         workspace = web_testapp.get(
             "/api/workspaces/{}".format(on_request_workspace.workspace_id), status=200
         ).json_body
-        assert last_event.workspace == workspace
+        assert last_event.workspace == {k: v for k, v in workspace.items() if k != "description"}
         assert last_event.subscription["state"] == subscription["state"]
         assert last_event.subscription["workspace"] == subscription["workspace"]
         assert last_event.subscription["author"] == subscription["author"]
@@ -304,7 +304,7 @@ class TestUserSubscriptionEndpoint(object):
         workspace = web_testapp.get(
             "/api/workspaces/{}".format(on_request_workspace.workspace_id), status=200
         ).json_body
-        assert last_event.workspace == workspace
+        assert last_event.workspace == {k: v for k, v in workspace.items() if k != "description"}
         assert last_event.subscription["state"] == subscription["state"]
         assert last_event.subscription["workspace"] == subscription["workspace"]
         assert last_event.subscription["author"] == subscription["author"]

--- a/backend/tracim_backend/tests/functional/test_workspaces.py
+++ b/backend/tracim_backend/tests/functional/test_workspaces.py
@@ -1633,7 +1633,7 @@ class TestWorkspaceMembersEndpoint(object):
             "do_notify": user_role_found["do_notify"],
         }
         workspace = web_testapp.get("/api/workspaces/1", status=200).json_body
-        assert last_event.workspace == workspace
+        assert last_event.workspace == {k: v for k, v in workspace.items() if k != "description"}
         author = web_testapp.get("/api/users/1", status=200).json_body
         assert last_event.author == user_schema.dump(author).data
         user = web_testapp.get("/api/users/2", status=200).json_body
@@ -1998,7 +1998,9 @@ class TestWorkspaceMembersEndpoint(object):
         workspace_dict = web_testapp.get(
             "/api/workspaces/{}".format(workspace.workspace_id), status=200
         ).json_body
-        assert last_event.workspace == workspace_dict
+        assert last_event.workspace == {
+            k: v for k, v in workspace_dict.items() if k != "description"
+        }
         author = web_testapp.get("/api/users/{}".format(user.user_id), status=200).json_body
         assert last_event.author == user_schema.dump(author).data
 
@@ -2285,7 +2287,9 @@ class TestWorkspaceMembersEndpoint(object):
         workspace_dict = web_testapp.get(
             "/api/workspaces/{}".format(workspace.workspace_id), status=200
         ).json_body
-        assert last_event.workspace == workspace_dict
+        assert last_event.workspace == {
+            k: v for k, v in workspace_dict.items() if k != "description"
+        }
         author = web_testapp.get("/api/users/1", status=200).json_body
         assert last_event.author == user_schema.dump(author).data
         user_dict = web_testapp.get("/api/users/{}".format(user.user_id), status=200).json_body

--- a/backend/tracim_backend/views/core_api/schemas.py
+++ b/backend/tracim_backend/views/core_api/schemas.py
@@ -1285,7 +1285,8 @@ class WorkspaceDigestSchema(marshmallow.Schema):
     label = StrippedString(example="Intranet")
 
 
-class WorkspaceSchema(WorkspaceDigestSchema):
+# NOTE - SG - 2021-04-29 - Used to avoid transmitting description in all TLMs
+class WorkspaceWithoutDescriptionSchema(WorkspaceDigestSchema):
     access_type = StrippedString(
         example=WorkspaceAccessType.CONFIDENTIAL.value,
         validate=workspace_access_type_validator,
@@ -1297,7 +1298,6 @@ class WorkspaceSchema(WorkspaceDigestSchema):
         required=True,
         description="default role for new users in this workspace",
     )
-    description = StrippedString(example="All intranet data.")
     created = marshmallow.fields.DateTime(
         format=DATETIME_FORMAT, description="Workspace creation date"
     )
@@ -1326,6 +1326,10 @@ class WorkspaceSchema(WorkspaceDigestSchema):
         default=True,
         description="define whether a user can create and view publications in this workspace",
     )
+
+
+class WorkspaceSchema(WorkspaceWithoutDescriptionSchema):
+    description = StrippedString(example="All intranet data.")
 
     class Meta:
         description = "Full workspace information"


### PR DESCRIPTION
See #4557.

<!-- Here, you can write a short summary of what the pull request brings. If a related issue exists, please reference it here -->

## Checkpoints

<!-- These points must be checked before merging. Please don't edit them out. -->

**For developers**

- [x] If relevant, manual tests have been done to ensure the stability of the whole application and that the involved feature works
- [x] The original issue is up to date w.r.t the latest discussions and contains a short summary of the implemented solution
- [x] Automated tests covering the feature or the fix, have been written, deemed irrelevant (give the reason), or an issue has been created to implement the test (give the link)
- [x] Make sure that:
  - if there are modifications in the Tracim configuration files (eg. `development.ini`), they are documented in `backend/doc/setting.md`
  - any migration process required for existing instances is documented
  - relevant people for these changes are notified
- [x] Original authors of the features included in a multi-feature branch (maintenance fixes -> develop, security fixes -> develop, …) should be part of the reviewers, especially if you encountered merge conflicts.

**For code reviewers**

- [x] The code is clear enough
- [x] If there are FIXMEs in the code, related issues are mentioned in the FIXME
- [x] If there are TODOs, NOTEs or HACKs in code, the date and the developer initials are present

**For testers**

- [x] Manual, quality tests have been done

### testing hints

- Before using this PR's branch, create a space with a description including an image. Add some contents to it.
- Check the time (and size of `messages` response) when displaying the recent activities of the space. Browsers include a throttle capability in devtools to decrease the download speed.
- Checkout this branch and restart `./run_dev_backend.sh`. Check that the time and size of `messages` response has dropped.
- Add other contents and recheck
- Navigate to the pages displaying the spaces' descriptions (dashboard, join space, space admin) and check that their display is updated when the description is modified through another browser tab.