### PR TITLE
fix(frontend, backend): add link lifetime to mail + proper message

### DIFF
--- a/backend/tracim_backend/locale/de/LC_MESSAGES/tracim_backend.po
+++ b/backend/tracim_backend/locale/de/LC_MESSAGES/tracim_backend.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tracim_backend 3.7.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-05-03 12:31+0200\n"
+"POT-Creation-Date: 2021-06-29 12:15+0200\n"
 "PO-Revision-Date: 2021-04-30 16:42+0100\n"
 "Last-Translator: marie <marie.begue@algoo.fr>\n"
 "Language: de\n"
@@ -20,7 +20,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.6.0\n"
 
-#: tracim_backend/config.py:628
+#: tracim_backend/config.py:651
 msgid ""
 "[{website_title}] [{workspace_label}] {content_label} "
 "({content_status_label})"
@@ -28,11 +28,11 @@ msgstr ""
 "[{website_title}] [{workspace_label}] {content_label} "
 "({content_status_label})"
 
-#: tracim_backend/config.py:637
+#: tracim_backend/config.py:660
 msgid "[{website_title}] Someone created an account for you"
 msgstr "[{website_title}] Jemand hat ein Konto für Sie erstellt"
 
-#: tracim_backend/config.py:647
+#: tracim_backend/config.py:670
 msgid "[{website_title}] A password reset has been requested"
 msgstr "[{website_title}] Ein Passwort-Reset wurde angefordert"
 
@@ -102,11 +102,11 @@ msgstr "Nachricht von {username}: {message}"
 msgid "Uploaded by {username}."
 msgstr "Hochgeladen von {username}."
 
-#: tracim_backend/lib/core/content.py:2082
+#: tracim_backend/lib/core/content.py:1896
 msgid "New folder"
 msgstr "Neuer Ordner"
 
-#: tracim_backend/lib/core/content.py:2087
+#: tracim_backend/lib/core/content.py:1901
 msgid "New folder {0}"
 msgstr "Neuer Ordner {0}"
 
@@ -147,8 +147,8 @@ msgid ""
 "Reply to this email directly or <a href=\"{call_to_action_url}\">view it "
 "on tracim</a>"
 msgstr ""
-"Antworten Sie direkt auf diese E-Mail oder <a href=\"{call_to_action_url}\">sehen Sie "
-"auf tracim</a>"
+"Antworten Sie direkt auf diese E-Mail oder <a "
+"href=\"{call_to_action_url}\">sehen Sie auf tracim</a>"
 
 #: tracim_backend/templates/mail/content_update_body_html.mak:63
 msgid "<a href=\"{call_to_action_url}\">view it on tracim</a>"
@@ -222,7 +222,7 @@ msgstr "Schönen Tag noch :)"
 
 #: tracim_backend/templates/mail/created_account_body_html.mak:25
 #: tracim_backend/templates/mail/new_upload_event_body_html.mak:17
-#: tracim_backend/templates/mail/reset_password_body_html.mak:18
+#: tracim_backend/templates/mail/reset_password_body_html.mak:20
 #: tracim_backend/templates/mail/shared_content_to_emitter_body_html.mak:17
 #: tracim_backend/templates/mail/upload_permission_to_emitter_body_html.mak:17
 msgid "Suricat', your digital assistant"
@@ -230,7 +230,7 @@ msgstr "Suricat', Ihr digitaler Assistent"
 
 #: tracim_backend/templates/mail/created_account_body_html.mak:29
 #: tracim_backend/templates/mail/new_upload_event_body_html.mak:21
-#: tracim_backend/templates/mail/reset_password_body_html.mak:22
+#: tracim_backend/templates/mail/reset_password_body_html.mak:24
 #: tracim_backend/templates/mail/shared_content_to_emitter_body_html.mak:21
 #: tracim_backend/templates/mail/upload_permission_to_emitter_body_html.mak:21
 msgid "Suricat', the bot"
@@ -238,7 +238,7 @@ msgstr "Suricat', der Bot"
 
 #: tracim_backend/templates/mail/created_account_body_html.mak:32
 #: tracim_backend/templates/mail/new_upload_event_body_html.mak:24
-#: tracim_backend/templates/mail/reset_password_body_html.mak:25
+#: tracim_backend/templates/mail/reset_password_body_html.mak:27
 #: tracim_backend/templates/mail/shared_content_to_emitter_body_html.mak:24
 #: tracim_backend/templates/mail/shared_content_to_receiver_body_html.mak:32
 #: tracim_backend/templates/mail/upload_permission_to_emitter_body_html.mak:24
@@ -287,6 +287,10 @@ msgid "If the link is not working, I suggest to copy/paste the full url: "
 msgstr ""
 "Wenn der Link nicht funktioniert, empfehle ich Ihnen, die vollständige "
 "URL zu kopieren/einzufügen: "
+
+#: tracim_backend/templates/mail/reset_password_body_html.mak:18
+msgid "The link is valid for {} minutes."
+msgstr "Der Link ist für {} Minuten gültig."
 
 #: tracim_backend/templates/mail/shared_content_to_emitter_body_html.mak:5
 msgid "You shared the file <i>{content_filename}</i> with:"
@@ -384,4 +388,3 @@ msgstr ""
 "Dieser Upload ist durch ein Passwort geschützt, bitte kontaktieren Sie "
 "mich (<a href=\"mailto:{emitter_email}\">{username}</a>), um das Passwort"
 " zu erhalten."
-

--- a/backend/tracim_backend/locale/en/LC_MESSAGES/tracim_backend.po
+++ b/backend/tracim_backend/locale/en/LC_MESSAGES/tracim_backend.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tracim_backend 1.9.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-05-03 12:31+0200\n"
+"POT-Creation-Date: 2021-06-29 12:15+0200\n"
 "PO-Revision-Date: 2018-08-21 15:04+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -14,17 +14,17 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.6.0\n"
 
-#: tracim_backend/config.py:628
+#: tracim_backend/config.py:651
 msgid ""
 "[{website_title}] [{workspace_label}] {content_label} "
 "({content_status_label})"
 msgstr ""
 
-#: tracim_backend/config.py:637
+#: tracim_backend/config.py:660
 msgid "[{website_title}] Someone created an account for you"
 msgstr ""
 
-#: tracim_backend/config.py:647
+#: tracim_backend/config.py:670
 msgid "[{website_title}] A password reset has been requested"
 msgstr ""
 
@@ -84,11 +84,11 @@ msgstr ""
 msgid "Uploaded by {username}."
 msgstr ""
 
-#: tracim_backend/lib/core/content.py:2082
+#: tracim_backend/lib/core/content.py:1896
 msgid "New folder"
 msgstr ""
 
-#: tracim_backend/lib/core/content.py:2087
+#: tracim_backend/lib/core/content.py:1901
 msgid "New folder {0}"
 msgstr ""
 
@@ -193,7 +193,7 @@ msgstr ""
 
 #: tracim_backend/templates/mail/created_account_body_html.mak:25
 #: tracim_backend/templates/mail/new_upload_event_body_html.mak:17
-#: tracim_backend/templates/mail/reset_password_body_html.mak:18
+#: tracim_backend/templates/mail/reset_password_body_html.mak:20
 #: tracim_backend/templates/mail/shared_content_to_emitter_body_html.mak:17
 #: tracim_backend/templates/mail/upload_permission_to_emitter_body_html.mak:17
 msgid "Suricat', your digital assistant"
@@ -201,7 +201,7 @@ msgstr ""
 
 #: tracim_backend/templates/mail/created_account_body_html.mak:29
 #: tracim_backend/templates/mail/new_upload_event_body_html.mak:21
-#: tracim_backend/templates/mail/reset_password_body_html.mak:22
+#: tracim_backend/templates/mail/reset_password_body_html.mak:24
 #: tracim_backend/templates/mail/shared_content_to_emitter_body_html.mak:21
 #: tracim_backend/templates/mail/upload_permission_to_emitter_body_html.mak:21
 msgid "Suricat', the bot"
@@ -209,7 +209,7 @@ msgstr ""
 
 #: tracim_backend/templates/mail/created_account_body_html.mak:32
 #: tracim_backend/templates/mail/new_upload_event_body_html.mak:24
-#: tracim_backend/templates/mail/reset_password_body_html.mak:25
+#: tracim_backend/templates/mail/reset_password_body_html.mak:27
 #: tracim_backend/templates/mail/shared_content_to_emitter_body_html.mak:24
 #: tracim_backend/templates/mail/shared_content_to_receiver_body_html.mak:32
 #: tracim_backend/templates/mail/upload_permission_to_emitter_body_html.mak:24
@@ -248,6 +248,10 @@ msgstr ""
 
 #: tracim_backend/templates/mail/reset_password_body_html.mak:14
 msgid "If the link is not working, I suggest to copy/paste the full url: "
+msgstr ""
+
+#: tracim_backend/templates/mail/reset_password_body_html.mak:18
+msgid "The link is valid for {} minutes."
 msgstr ""
 
 #: tracim_backend/templates/mail/shared_content_to_emitter_body_html.mak:5
@@ -336,4 +340,3 @@ msgstr ""
 #~ "to upload files in this shared "
 #~ "space <a href={sharedspace_url}>{sharedspace_name}</a>:"
 #~ msgstr ""
-

--- a/backend/tracim_backend/locale/fr/LC_MESSAGES/tracim_backend.po
+++ b/backend/tracim_backend/locale/fr/LC_MESSAGES/tracim_backend.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tracim_backend 1.9.1\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-05-03 12:31+0200\n"
+"POT-Creation-Date: 2021-06-29 12:15+0200\n"
 "PO-Revision-Date: 2018-08-21 15:04+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: fr\n"
@@ -18,17 +18,17 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.6.0\n"
 
-#: tracim_backend/config.py:628
+#: tracim_backend/config.py:651
 msgid ""
 "[{website_title}] [{workspace_label}] {content_label} "
 "({content_status_label})"
 msgstr ""
 
-#: tracim_backend/config.py:637
+#: tracim_backend/config.py:660
 msgid "[{website_title}] Someone created an account for you"
 msgstr "[{website_title}] Quelqu'un vous a créé un compte"
 
-#: tracim_backend/config.py:647
+#: tracim_backend/config.py:670
 msgid "[{website_title}] A password reset has been requested"
 msgstr "[{website_title}] Demande de réinitialisation de mot de passe"
 
@@ -98,11 +98,11 @@ msgstr "Message de {username} : {message}"
 msgid "Uploaded by {username}."
 msgstr "Téléversé par {username}."
 
-#: tracim_backend/lib/core/content.py:2082
+#: tracim_backend/lib/core/content.py:1896
 msgid "New folder"
 msgstr "Nouveau dossier"
 
-#: tracim_backend/lib/core/content.py:2087
+#: tracim_backend/lib/core/content.py:1901
 msgid "New folder {0}"
 msgstr "Nouveau dossier {0}"
 
@@ -217,7 +217,7 @@ msgstr "Bonne journée :)"
 
 #: tracim_backend/templates/mail/created_account_body_html.mak:25
 #: tracim_backend/templates/mail/new_upload_event_body_html.mak:17
-#: tracim_backend/templates/mail/reset_password_body_html.mak:18
+#: tracim_backend/templates/mail/reset_password_body_html.mak:20
 #: tracim_backend/templates/mail/shared_content_to_emitter_body_html.mak:17
 #: tracim_backend/templates/mail/upload_permission_to_emitter_body_html.mak:17
 msgid "Suricat', your digital assistant"
@@ -225,7 +225,7 @@ msgstr "Suricate, votre assistant numérique"
 
 #: tracim_backend/templates/mail/created_account_body_html.mak:29
 #: tracim_backend/templates/mail/new_upload_event_body_html.mak:21
-#: tracim_backend/templates/mail/reset_password_body_html.mak:22
+#: tracim_backend/templates/mail/reset_password_body_html.mak:24
 #: tracim_backend/templates/mail/shared_content_to_emitter_body_html.mak:21
 #: tracim_backend/templates/mail/upload_permission_to_emitter_body_html.mak:21
 msgid "Suricat', the bot"
@@ -233,7 +233,7 @@ msgstr "Suricate, le robot"
 
 #: tracim_backend/templates/mail/created_account_body_html.mak:32
 #: tracim_backend/templates/mail/new_upload_event_body_html.mak:24
-#: tracim_backend/templates/mail/reset_password_body_html.mak:25
+#: tracim_backend/templates/mail/reset_password_body_html.mak:27
 #: tracim_backend/templates/mail/shared_content_to_emitter_body_html.mak:24
 #: tracim_backend/templates/mail/shared_content_to_receiver_body_html.mak:32
 #: tracim_backend/templates/mail/upload_permission_to_emitter_body_html.mak:24
@@ -284,6 +284,10 @@ msgid "If the link is not working, I suggest to copy/paste the full url: "
 msgstr ""
 "Si le lien ne fonctionne pas, Je vous suggère de copier/coller l'url "
 "entière :"
+
+#: tracim_backend/templates/mail/reset_password_body_html.mak:18
+msgid "The link is valid for {} minutes."
+msgstr "Le lien est valide pendant {} minutes."
 
 #: tracim_backend/templates/mail/shared_content_to_emitter_body_html.mak:5
 msgid "You shared the file <i>{content_filename}</i> with:"
@@ -377,4 +381,3 @@ msgstr ""
 "Le téléversement est protégé par un mot de passe, merci de me contacter "
 "(<a href=\"mailto:{emitter_email}\">{username}</a>) pour avoir le mot de "
 "passe."
-

--- a/backend/tracim_backend/locale/pt/LC_MESSAGES/tracim_backend.po
+++ b/backend/tracim_backend/locale/pt/LC_MESSAGES/tracim_backend.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tracim_backend 2.6.3\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2021-05-03 12:31+0200\n"
+"POT-Creation-Date: 2021-06-29 12:15+0200\n"
 "PO-Revision-Date: 2020-04-15 16:26+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: pt\n"
@@ -19,17 +19,17 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.6.0\n"
 
-#: tracim_backend/config.py:628
+#: tracim_backend/config.py:651
 msgid ""
 "[{website_title}] [{workspace_label}] {content_label} "
 "({content_status_label})"
 msgstr ""
 
-#: tracim_backend/config.py:637
+#: tracim_backend/config.py:660
 msgid "[{website_title}] Someone created an account for you"
 msgstr "[{website_title}] Alguém criou uma conta para você"
 
-#: tracim_backend/config.py:647
+#: tracim_backend/config.py:670
 msgid "[{website_title}] A password reset has been requested"
 msgstr "[{website_title}] Uma reposição da palavra-passe foi pedida"
 
@@ -97,11 +97,11 @@ msgstr "Mensagem de {username}: {message}"
 msgid "Uploaded by {username}."
 msgstr "Subido por {username}."
 
-#: tracim_backend/lib/core/content.py:2082
+#: tracim_backend/lib/core/content.py:1896
 msgid "New folder"
 msgstr "Nova pasta"
 
-#: tracim_backend/lib/core/content.py:2087
+#: tracim_backend/lib/core/content.py:1901
 msgid "New folder {0}"
 msgstr "Nova pasta {0}"
 
@@ -217,7 +217,7 @@ msgstr "Aproveite o seu dia :)"
 
 #: tracim_backend/templates/mail/created_account_body_html.mak:25
 #: tracim_backend/templates/mail/new_upload_event_body_html.mak:17
-#: tracim_backend/templates/mail/reset_password_body_html.mak:18
+#: tracim_backend/templates/mail/reset_password_body_html.mak:20
 #: tracim_backend/templates/mail/shared_content_to_emitter_body_html.mak:17
 #: tracim_backend/templates/mail/upload_permission_to_emitter_body_html.mak:17
 msgid "Suricat', your digital assistant"
@@ -225,7 +225,7 @@ msgstr "Suricato, o seu assistente digital"
 
 #: tracim_backend/templates/mail/created_account_body_html.mak:29
 #: tracim_backend/templates/mail/new_upload_event_body_html.mak:21
-#: tracim_backend/templates/mail/reset_password_body_html.mak:22
+#: tracim_backend/templates/mail/reset_password_body_html.mak:24
 #: tracim_backend/templates/mail/shared_content_to_emitter_body_html.mak:21
 #: tracim_backend/templates/mail/upload_permission_to_emitter_body_html.mak:21
 msgid "Suricat', the bot"
@@ -233,7 +233,7 @@ msgstr "Suricato, o robô"
 
 #: tracim_backend/templates/mail/created_account_body_html.mak:32
 #: tracim_backend/templates/mail/new_upload_event_body_html.mak:24
-#: tracim_backend/templates/mail/reset_password_body_html.mak:25
+#: tracim_backend/templates/mail/reset_password_body_html.mak:27
 #: tracim_backend/templates/mail/shared_content_to_emitter_body_html.mak:24
 #: tracim_backend/templates/mail/shared_content_to_receiver_body_html.mak:32
 #: tracim_backend/templates/mail/upload_permission_to_emitter_body_html.mak:24
@@ -278,6 +278,10 @@ msgstr "Repor minha palavra-passe"
 #: tracim_backend/templates/mail/reset_password_body_html.mak:14
 msgid "If the link is not working, I suggest to copy/paste the full url: "
 msgstr "Se o link não estiver funcionando, sugiro copiar/colar a url completa: "
+
+#: tracim_backend/templates/mail/reset_password_body_html.mak:18
+msgid "The link is valid for {} minutes."
+msgstr "A ligação é válida por {} minutos."
 
 #: tracim_backend/templates/mail/shared_content_to_emitter_body_html.mak:5
 msgid "You shared the file <i>{content_filename}</i> with:"
@@ -374,4 +378,3 @@ msgstr ""
 "Esse upload é protegido por uma palavra-passe, por favor contacte-me (<a "
 "href=\"mailto:{emitter_email}\">{username}</a>) para obter a palavra-"
 "passe."
-

--- a/backend/tracim_backend/templates/mail/reset_password_body_html.mak
+++ b/backend/tracim_backend/templates/mail/reset_password_body_html.mak
@@ -15,6 +15,9 @@
 </p>
 <pre>${reset_password_url}</pre>
 
+## the lifetime is converted from seconds to minutes.
+${_('The link is valid for {} minutes.'.format(config.USER__RESET_PASSWORD__TOKEN_LIFETIME // 60))}
+
 <p>${_("Suricat', your digital assistant")}</p>
 
 <pre>

--- a/backend/tracim_backend/tests/functional/test_mail_notification.py
+++ b/backend/tracim_backend/tests/functional/test_mail_notification.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 # INFO - G.M - 09-06-2018 - Those test need a working MailHog
 
+import email
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 
@@ -246,6 +247,8 @@ class TestNotificationsSync(object):
         assert headers["From"][0] == "Tracim Notifications <test_user_from+0@localhost>"
         assert headers["To"][0] == "Global manager <admin@admin.admin>"
         assert headers["Subject"][0] == "[Tracim] A password reset has been requested"
+        message = email.message_from_string(response[0]["Raw"]["Data"], policy=email.policy.default)
+        assert "This link is valid for 15 minutes" in message.get_body().get_content()
 
 
 @pytest.mark.usefixtures("base_fixture")

--- a/frontend/i18next.scanner/de/translation.json
+++ b/frontend/i18next.scanner/de/translation.json
@@ -473,5 +473,6 @@
   "Alex Doe": "Alex Müller",
   "alex.doe@jco.co": "alex.muller@alm.de",
   "In order to finish your sign in, please read the following usage conditions and accept them": "Um Ihre Anmeldung abzuschließen, lesen Sie bitte die folgenden Nutzungsbedingungen und akzeptieren Sie diese",
-  "Unknown content": "Unbekannter Inhalt"
+  "Unknown content": "Unbekannter Inhalt",
+  "Your reset password link has expired, you can regenerate one by following <1>this link</1>.": "Ihr Link für das Zurücksetzen des Passworts ist abgelaufen, Sie können eines erneuern, indem Sie <1>diesem Link</1> folgen."
 }

--- a/frontend/i18next.scanner/en/translation.json
+++ b/frontend/i18next.scanner/en/translation.json
@@ -473,5 +473,6 @@
   "Alex Doe": "Alex Doe",
   "alex.doe@jco.co": "alex.doe@jco.co",
   "In order to finish your sign in, please read the following usage conditions and accept them": "In order to finish your sign in, please read the following usage conditions and accept them",
-  "Unknown content": "Unknown content"
+  "Unknown content": "Unknown content",
+  "Your reset password link has expired, you can regenerate one by following <1>this link</1>.": "Your reset password link has expired, you can regenerate one by following <1>this link</1>."
 }

--- a/frontend/i18next.scanner/fr/translation.json
+++ b/frontend/i18next.scanner/fr/translation.json
@@ -473,5 +473,6 @@
   "Alex Doe": "Alix Martin",
   "alex.doe@jco.co": "alix.martin@alm.fr",
   "In order to finish your sign in, please read the following usage conditions and accept them": "Pour finaliser votre connexion, merci de prendre connaissance des conditions d'utilisation et de les valider",
-  "Unknown content": "Contenu inconnu"
+  "Unknown content": "Contenu inconnu",
+  "Your reset password link has expired, you can regenerate one by following <1>this link</1>.": "Votre lien de ré-initialisation de mot de passe a expiré, vous pouvez le regénérer en suivant <1>ce lien</1>."
 }

--- a/frontend/i18next.scanner/pt/translation.json
+++ b/frontend/i18next.scanner/pt/translation.json
@@ -474,5 +474,5 @@
   "alex.doe@jco.co": "carmo.dasilva@cds.pt",
   "In order to finish your sign in, please read the following usage conditions and accept them": "Para terminar a sua sessão, por favor leia as seguintes condições de utilização e aceite-as",
   "Unknown content": "Conteúdo desconhecido",
-  "Your reset password link has expired, you can regenerate one by following <1>this link</1>.": "O ligação da sua senha de reinicialização expirou, pode regenerar um, clicando <1>nesta ligação</1>."
+  "Your reset password link has expired, you can regenerate one by following <1>this link</1>.": "A ligação da sua senha de reinicialização expirou, pode regenerar uma nova clicando <1>nesta ligação</1>."
 }

--- a/frontend/i18next.scanner/pt/translation.json
+++ b/frontend/i18next.scanner/pt/translation.json
@@ -473,5 +473,6 @@
   "Alex Doe": "Carmo Da Silva",
   "alex.doe@jco.co": "carmo.dasilva@cds.pt",
   "In order to finish your sign in, please read the following usage conditions and accept them": "Para terminar a sua sessão, por favor leia as seguintes condições de utilização e aceite-as",
-  "Unknown content": "Conteúdo desconhecido"
+  "Unknown content": "Conteúdo desconhecido",
+  "Your reset password link has expired, you can regenerate one by following <1>this link</1>.": "O ligação da sua senha de reinicialização expirou, pode regenerar um, clicando <1>nesta ligação</1>."
 }

--- a/frontend/src/container/ResetPassword.jsx
+++ b/frontend/src/container/ResetPassword.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { connect } from 'react-redux'
-import { translate } from 'react-i18next'
-import { withRouter } from 'react-router-dom'
+import { translate, Trans } from 'react-i18next'
+import { withRouter, Link } from 'react-router-dom'
 import Card from '../component/common/Card/Card.jsx'
 import CardHeader from '../component/common/Card/CardHeader.jsx'
 import CardBody from '../component/common/Card/CardBody.jsx'
@@ -106,6 +106,21 @@ export class ResetPassword extends React.Component {
       case 204:
         props.history.push(PAGE.LOGIN)
         props.dispatch(newFlashMessage(props.t('Your password has been changed, you can now login'), 'info'))
+        break
+      case 400:
+        switch (fetchPostResetPassword.json.code) {
+          case 2040: {
+            const message = (
+              <Trans>
+                Your reset password link has expired, you can regenerate one by following&nbsp;
+                <Link to={PAGE.FORGOT_PASSWORD}>this link</Link>.
+              </Trans>
+            )
+            props.dispatch(newFlashMessage(message, 'warning'))
+            break
+          }
+          default: props.dispatch(newFlashMessage(props.t('An error has happened, please try again'), 'warning'))
+        }
         break
       default: props.dispatch(newFlashMessage(props.t('An error has happened, please try again'), 'warning'))
     }


### PR DESCRIPTION
<!-- Here, you can write a short summary of what the pull request brings. If a related issue exists, please reference it here -->
See #4759

## Checkpoints

<!-- These points must be checked before merging. Please don't edit them out. -->

**For developers**

- [x] If relevant, manual tests have been done to ensure the stability of the whole application and that the involved feature works
- [x] The original issue is up to date w.r.t the latest discussions and contains a short summary of the implemented solution
- [x] Automated tests covering the feature or the fix, have been written, deemed irrelevant (give the reason), or an issue has been created to implement the test (give the link)
- [x] Make sure that:
  - if there are modifications in the Tracim configuration files (eg. `development.ini`), they are documented in `backend/doc/setting.md`
  - any migration process required for existing instances is documented
  - relevant people for these changes are notified
- [x] Original authors of the features included in a multi-feature branch (maintenance fixes -> develop, security fixes -> develop, …) should be part of the reviewers, especially if you encountered merge conflicts.

**For code reviewers**

- [x] The code is clear enough
- [x] If there are FIXMEs in the code, related issues are mentioned in the FIXME
- [x] If there are TODOs, NOTEs or HACKs in code, the date and the developer initials are present

**For testers**

- [x] Manual, quality tests have been done

**Testing method**

- Start the backend with:
```shell
cd backend
docker-compose up -d
export TRACIM_EMAIL__NOTIFICATION__FROM__EMAIL=test@test.te
export TRACIM_EMAIL__NOTIFICATION__REPLY_TO__EMAIL=test@test.te
export TRACIM_EMAIL__NOTIFICATION__REFERENCES__EMAIL=test@test.te
export TRACIM_EMAIL__NOTIFICATION__ACTIVATED=True
export TRACIM_EMAIL__NOTIFICATION__SMTP__SERVER=localhost
export TRACIM_EMAIL__NOTIFICATION__SMTP__PORT=1025
export TRACIM_EMAIL__NOTIFICATION__SMTP__USER=user
export TRACIM_EMAIL__NOTIFICATION__SMTP__PASSWORD=password
pserve development.ini
```
- Request a password reset through the UI
- Go to http://localhost:8025 to read the password reset mail.

