### PR TITLE
fix(frontend): avoid pending draft when saving a note after clicking …

### DIFF
--- a/frontend/test/src/container/Header.spec.js
+++ b/frontend/test/src/container/Header.spec.js
@@ -9,13 +9,11 @@ import {
   USER,
   USER_DISCONNECTED
 } from '../../../src/action-creator.sync.js'
-import { FETCH_CONFIG } from '../../../src/util/helper.js'
 import {
   restoreHistoryCallBack,
   isFunction
 } from '../../hocMock/helper'
 import { shallow } from 'enzyme'
-import { mockPostUserLogout204 } from '../../apiMock'
 
 describe('In <Header />', () => {
   const setUserDisconnectedCallBack = sinon.spy()

--- a/frontend_lib/src/tinymceAutoCompleteHelper.js
+++ b/frontend_lib/src/tinymceAutoCompleteHelper.js
@@ -147,6 +147,17 @@ export const tinymceAutoCompleteHandleClickItem = (autoCompleteItem, setState) =
 
   sel.anchorNode.textContent = textBegin + textEnd
   sel.collapse(sel.anchorNode, textBegin.length)
+
+  // NOTE - RJ - 2021-07-08 - focusing the editor lets TinyMCE execute its cleanups
+  // routine. If we don't do this and the user saves the document right after an
+  // autocompletion and the user picked the autocompletion item by clicking on it
+  // (as opposed to pressing the enter key), the editor never receives the focus
+  // and do its cleanups after removing TinyMCE and this happens asynchronously.
+  // This modifies the document and saves the result in the draft stored in
+  // local storage after posting the document on the API. Then, we tell the
+  // user that they have a pending draft, which is confusing.
+  globalThis.tinymce.activeEditor.focus()
+
   setState({ isAutoCompleteActivated: false })
 }
 


### PR DESCRIPTION
This fixes the pending draft after saving right after clicking an autocompletion. This is done by focusing the TinyMCE editor after autocompletion so it triggers its cleanup routine at this moment and not after saving.

<!-- Here, you can write a short summary of what the pull request brings. If a related issue exists, please reference it here -->

## Checkpoints

<!-- These points must be checked before merging. Please don't edit them out. -->

**For developers**

- [X] If relevant, manual tests have been done to ensure the stability of the whole application and that the involved feature works
- [X] No original issue
- [X] No automated tests
- [ ] Make sure that:
  - if there are modifications in the Tracim configuration files (eg. `development.ini`), they are documented in `backend/doc/setting.md`
  - any migration process required for existing instances is documented
  - relevant people for these changes are notified
- [X] Original authors of the features included in a multi-feature branch (maintenance fixes -> develop, security fixes -> develop, …) should be part of the reviewers, especially if you encountered merge conflicts.

**For code reviewers**

- [x] The code is clear enough
- [x] If there are FIXMEs in the code, related issues are mentioned in the FIXME
- [x] If there are TODOs, NOTEs or HACKs in code, the date and the developer initials are present

**For testers**

- [ ] Manual, quality tests have been done
