### PR TITLE
Fix(docker): fix wrong apache2 syntax used for directive ProxyPass

### DIFF
--- a/backend/doc/apache.md
+++ b/backend/doc/apache.md
@@ -58,7 +58,7 @@ Create a file named `/etc/apache2/sites-available/tracim.conf` containing:
     ProxyPassMatch ^/custom_toolbox-assets uwsgi://127.0.0.1:6544
     ProxyPassReverse /custom_toolbox-assets uwsgi://127.0.0.1:6544
 
-    ProxyPassMatch ^/$ uwsgi://127.0.0.1:6544/
+    ProxyPassMatch ^/$ uwsgi://127.0.0.1:6544
     ProxyPassReverse / uwsgi://127.0.0.1:6544/
 
     CustomLog /var/log/apache2/apache2-tracim-access.log combined

--- a/tools_docker/Debian_New_Uwsgi/apache2.conf.sample
+++ b/tools_docker/Debian_New_Uwsgi/apache2.conf.sample
@@ -64,7 +64,7 @@
     ProxyPassMatch ^/custom_toolbox-assets uwsgi://127.0.0.1:8081
     ProxyPassReverse /custom_toolbox-assets uwsgi://127.0.0.1:8081
 
-    ProxyPassMatch ^/$ uwsgi://127.0.0.1:8081/
+    ProxyPassMatch ^/$ uwsgi://127.0.0.1:8081
     ProxyPassReverse / uwsgi://127.0.0.1:8081/
 
     CustomLog /var/tracim/logs/apache2-access.log combined

--- a/tools_docker/Debian_Uwsgi/apache2.conf.sample
+++ b/tools_docker/Debian_Uwsgi/apache2.conf.sample
@@ -64,7 +64,7 @@
     ProxyPassMatch ^/custom_toolbox-assets uwsgi://127.0.0.1:8081
     ProxyPassReverse /custom_toolbox-assets uwsgi://127.0.0.1:8081
 
-    ProxyPassMatch ^/$ uwsgi://127.0.0.1:8081/
+    ProxyPassMatch ^/$ uwsgi://127.0.0.1:8081
     ProxyPassReverse / uwsgi://127.0.0.1:8081/
 
     CustomLog /var/tracim/logs/apache2-access.log combined


### PR DESCRIPTION
Ref: #4991

This fix is necessary to make sure Tracim not reply with wrong URL.
Need to check if all directive is correct and if all files available in repository show now the good syntax.

I have tested this configuration before creating pull request but just about login page and small navigation inside Tracim. This is not a big fix but we just need to check if I have done the right modification everywhere is necessary.

For reviewers:
Fix is about this documentation http://httpd.apache.org/docs/2.4/en/mod/mod_proxy.html#proxypass and this part:
~~~
If the first argument ends with a trailing /, the second argument should also end with a trailing /, and vice versa. Otherwise, the resulting requests to the backend may miss some needed slashes and do not deliver the expected results.
~~~

## Checkpoints

<!-- These points must be checked before merging. Please don't edit them out. -->

**For developers**

- [x] If relevant, manual tests have been done to ensure the stability of the whole application and that the involved feature works
- [x] The original issue is up to date w.r.t the latest discussions and contains a short summary of the implemented solution
- [x] Automated tests covering the feature or the fix, have been written, deemed irrelevant (give the reason), or an issue has been created to implement the test (give the link)
- [x] Make sure that:
  - if there are modifications in the Tracim configuration files (eg. `development.ini`), they are documented in `backend/doc/setting.md`
  - any migration process required for existing instances is documented
  - relevant people for these changes are notified
- [x] Original authors of the features included in a multi-feature branch (maintenance fixes -> develop, security fixes -> develop, …) should be part of the reviewers, especially if you encountered merge conflicts.

**For code reviewers**

- [x] The code is clear enough
- [x] If there are FIXMEs in the code, related issues are mentioned in the FIXME
- [x] If there are TODOs, NOTEs or HACKs in code, the date and the developer initials are present

**For testers**

- [x] Manual, quality tests have been done
