### PR TITLE
Feat(frontend) Added a close button on call popup

### DIFF
--- a/frontend/src/container/Tracim.jsx
+++ b/frontend/src/container/Tracim.jsx
@@ -615,6 +615,7 @@ export class Tracim extends React.Component {
           </CardPopup>
         )}
 
+        {/* INFO - MP - 2021-10-15: Call popup */}
         {state.userCall && (state.userCall.caller.user_id === props.user.userId) && state.userCall.state === USER_CALL_STATE.IN_PROGRESS && (
           <CardPopup
             customClass=''
@@ -647,6 +648,7 @@ export class Tracim extends React.Component {
             </div>
           </CardPopup>
         )}
+        {/* INFO - MP - 2021-10-15: Declined popup */}
         {state.userCall && (state.userCall.caller.user_id === props.user.userId) && state.userCall.state === USER_CALL_STATE.REJECTED && (
           <CardPopup
             customClass='callpopup__body'
@@ -654,8 +656,10 @@ export class Tracim extends React.Component {
             onClose={this.handleClosePopup}
             label={props.t('Call declined by {{username}}', { username: state.userCall.callee.public_name })}
             faIcon='fas fa-phone-slash'
+            displayCloseButton
           />
         )}
+        {/* INFO - MP - 2021-10-15: Call back later popup */}
         {state.userCall && (state.userCall.caller.user_id === props.user.userId) && state.userCall.state === USER_CALL_STATE.DECLINED && (
           <CardPopup
             customClass='callpopup__body'
@@ -663,8 +667,10 @@ export class Tracim extends React.Component {
             onClose={this.handleClosePopup}
             label={props.t('{{username}} will call you back later', { username: state.userCall.callee.public_name })}
             faIcon='fas fa-phone-slash'
+            displayCloseButton
           />
         )}
+        {/* INFO - MP - 2021-10-15: Call failed popup */}
         {state.userCall && (state.userCall.caller.user_id === props.user.userId) && state.userCall.state === USER_CALL_STATE.UNANSWERED && (
           <CardPopup
             customClass='callpopup__body'
@@ -672,6 +678,7 @@ export class Tracim extends React.Component {
             onClose={this.handleClosePopup}
             label={props.t('Call failed')}
             faIcon='fas fa-phone-slash'
+            displayCloseButton
           >
             <div className='callpopup__text'>
               {props.t('The call with {{username}} failed', { username: state.userCall.callee.public_name })}
@@ -688,15 +695,6 @@ export class Tracim extends React.Component {
               />
             </div>
           </CardPopup>
-        )}
-        {state.userCall && (state.userCall.caller.user_id === props.user.userId) && state.userCall.state === USER_CALL_STATE.DECLINED && (
-          <CardPopup
-            customClass='callpopup__body'
-            customHeaderClass='primaryColorBg'
-            onClose={this.handleClosePopup}
-            label={props.t('{{username}} will call you back later', { username: state.userCall.callee.public_name })}
-            faIcon='fas fa-phone-slash'
-          />
         )}
 
         <ReduxTlmDispatcher />
@@ -857,7 +855,7 @@ export class Tracim extends React.Component {
         </div>
         {state.tooManyUsers && (
           <div className='tracim__pageBlock'>
-            <CardPopup hideCloseBtn customHeaderClass='bg-danger'>
+            <CardPopup displayCrossButton={false} customHeaderClass='bg-danger'>
               <div className='tracim__pageBlock__cardPopupContent'>
                 <div className='tracim__pageBlock__cardPopupContent__message'>
                   {props.t('You have reached the authorised number of simultaneous users. Please contact your administrator.')}

--- a/frontend_lib/src/component/CardPopup/CardPopup.jsx
+++ b/frontend_lib/src/component/CardPopup/CardPopup.jsx
@@ -2,8 +2,10 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import classnames from 'classnames'
 import CloseButton from '../Button/CloseButton.jsx'
+import IconButton from '../Button/IconButton.jsx'
+import { translate } from 'react-i18next'
 
-// require('./CardPopup.styl') // see https://github.com/tracim/tracim/issues/1156
+require('./CardPopup.styl')
 
 const CardPopup = props => {
   return (
@@ -29,7 +31,7 @@ const CardPopup = props => {
             </div>
           )}
 
-          {props.hideCloseBtn === false && (
+          {props.displayCrossButton && (
             <div className='cardPopup__header__close'>
               <CloseButton onClick={props.onClose} />
             </div>
@@ -38,20 +40,34 @@ const CardPopup = props => {
 
         <div className='cardPopup__body'>
           {props.children}
+
+          {props.displayCloseButton && (
+            <div className='cardPopup__body__close_btn'>
+              <IconButton
+                intent='primary'
+                mode='light'
+                onClick={props.onClose}
+                text={props.t('Close')}
+                icon='fas fa-times'
+                color={GLOBAL_primaryColor}
+              />
+            </div>
+          )}
         </div>
       </div>
     </div>
   )
 }
 
-export default CardPopup
+export default translate()(CardPopup)
 
 CardPopup.propTypes = {
   customClass: PropTypes.string,
   customHeaderClass: PropTypes.string,
   customColor: PropTypes.string,
   onClose: PropTypes.func,
-  hideCloseBtn: PropTypes.bool,
+  displayCrossButton: PropTypes.bool,
+  displayCloseButton: PropTypes.bool,
   customStyle: PropTypes.object
 }
 
@@ -60,6 +76,7 @@ CardPopup.defaultProps = {
   customHeaderClass: '',
   customColor: '',
   onClose: () => { },
-  hideCloseBtn: false,
+  displayCrossButton: true,
+  displayCloseButton: false,
   customStyle: {}
 }

--- a/frontend_lib/src/component/CardPopup/CardPopup.styl
+++ b/frontend_lib/src/component/CardPopup/CardPopup.styl
@@ -35,6 +35,9 @@
     display flex
     align-items center
     padding 0 pageSpacing pageSpacing
+    &__close_btn
+      margin-inline-start auto
+
 
 @media (max-width: max-xs)
   .cardPopup

--- a/frontend_lib/src/container/PopupProgressUpload.jsx
+++ b/frontend_lib/src/container/PopupProgressUpload.jsx
@@ -10,7 +10,7 @@ export const PopupProgressUpload = props =>
     customHeaderClass=''
     customColor={props.color}
     onClose={() => {}}
-    hideCloseBtn
+    displayCrossButton={false}
   >
     <div className='uploadPopup__body'>
       <ProgressBar


### PR DESCRIPTION
Issue: #5006

This PR bring a new (optional) close button on CardPopup.
Refactor `hideCloseBtn` (which was refering to the cross to close the popup) to `displayCrossButton` since we got two close buttons.

## Checkpoints

<!-- These points must be checked before merging. Please don't edit them out. -->

**For developers**

- [ ] If relevant, manual tests have been done to ensure the stability of the whole application and that the involved feature works
- [ ] The original issue is up to date w.r.t the latest discussions and contains a short summary of the implemented solution
- [ ] Automated tests covering the feature or the fix, have been written, deemed irrelevant (give the reason), or an issue has been created to implement the test (give the link)
- [ ] Make sure that:
  - if there are modifications in the Tracim configuration files (eg. `development.ini`), they are documented in `backend/doc/setting.md`
  - any migration process required for existing instances is documented
  - relevant people for these changes are notified
- [ ] Original authors of the features included in a multi-feature branch (maintenance fixes -> develop, security fixes -> develop, …) should be part of the reviewers, especially if you encountered merge conflicts.

**For code reviewers**

- [ ] The code is clear enough
- [ ] If there are FIXMEs in the code, related issues are mentioned in the FIXME
- [ ] If there are TODOs, NOTEs or HACKs in code, the date and the developer initials are present

**For testers**

- [ ] Manual, quality tests have been done
