### PR TITLE
Feat(frontent): New click handle on circle notification to read it without being redirected

### DIFF
--- a/frontend/src/component/NotificationItem.jsx
+++ b/frontend/src/component/NotificationItem.jsx
@@ -56,7 +56,15 @@ const NotificationItem = props => {
         </div>
       </div>
       <div className='notification__list__item__circle__wrapper'>
-        {!notification.read && <i className='notification__list__item__circle fas fa-circle' />}
+        {!notification.read &&
+          <i
+            className='notification__list__item__circle fas fa-circle'
+            onClick={(event) => {
+              event.preventDefault()
+              event.stopPropagation()
+              props.onClickCircle(notification.id)
+            }}
+          />}
       </div>
     </Link>
 
@@ -67,6 +75,7 @@ export default translate()(TracimComponent(NotificationItem))
 NotificationItem.propTypes = {
   getNotificationDetails: PropTypes.func.isRequired,
   notification: PropTypes.object.isRequired,
+  onClickCircle: PropTypes.func.isRequired,
   onClickNotification: PropTypes.func.isRequired,
   shortDate: PropTypes.func.isRequired,
   user: PropTypes.object.isRequired

--- a/frontend/src/container/GroupedNotificationItem.jsx
+++ b/frontend/src/container/GroupedNotificationItem.jsx
@@ -189,7 +189,15 @@ export class GroupedNotificationItem extends React.Component {
           </div>
         </div>
         <div className='notification__list__item__circle__wrapper'>
-          {!readStatus && <i className='notification__list__item__circle fas fa-circle' />}
+          {!readStatus &&
+          <i
+            className='notification__list__item__circle fas fa-circle'
+            onClick={(e) => {
+              notification.group.forEach(n => {
+                props.onClickCircle(n.id)
+              })
+            }}
+          />}
         </div>
       </Link>
 
@@ -203,6 +211,7 @@ export default connect(mapStateToProps)(translate()(TracimComponent(GroupedNotif
 GroupedNotificationItem.propTypes = {
   getNotificationDetails: PropTypes.func.isRequired,
   notification: PropTypes.object.isRequired,
+  onClickCircle: PropTypes.func.isRequired,
   onClickNotification: PropTypes.func.isRequired,
   shortDate: PropTypes.func.isRequired
 }

--- a/frontend/src/container/GroupedNotificationItem.jsx
+++ b/frontend/src/container/GroupedNotificationItem.jsx
@@ -190,14 +190,14 @@ export class GroupedNotificationItem extends React.Component {
         </div>
         <div className='notification__list__item__circle__wrapper'>
           {!readStatus &&
-          <i
-            className='notification__list__item__circle fas fa-circle'
-            onClick={(e) => {
-              notification.group.forEach(n => {
-                props.onClickCircle(n.id)
-              })
-            }}
-          />}
+            <i
+              className='notification__list__item__circle fas fa-circle'
+              onClick={(e) => {
+                notification.group.forEach(n => {
+                  props.onClickCircle(n.id)
+                })
+              }}
+            />}
         </div>
       </Link>
 

--- a/frontend/src/container/NotificationWall.jsx
+++ b/frontend/src/container/NotificationWall.jsx
@@ -60,6 +60,14 @@ export class NotificationWall extends React.Component {
       e.preventDefault()
     }
 
+    this.handleReadNotification(notificationId)
+
+    props.onCloseNotificationWall()
+  }
+
+  handleReadNotification = async (notificationId) => {
+    const { props } = this
+
     const fetchPutNotificationAsRead = await props.dispatch(putNotificationAsRead(props.user.userId, notificationId))
     switch (fetchPutNotificationAsRead.status) {
       case 204: {
@@ -69,8 +77,6 @@ export class NotificationWall extends React.Component {
       default:
         props.dispatch(newFlashMessage(props.t('Error while marking the notification as read'), 'warning'))
     }
-
-    props.onCloseNotificationWall()
   }
 
   handleClickSeeMore = async () => {
@@ -463,6 +469,7 @@ export class NotificationWall extends React.Component {
                       getNotificationDetails={this.getNotificationDetails}
                       notification={notification}
                       onClickNotification={this.handleClickNotification}
+                      onClickCircle={this.handleReadNotification}
                       shortDate={this.shortDate}
                     />
                   )
@@ -471,6 +478,7 @@ export class NotificationWall extends React.Component {
                       getNotificationDetails={this.getNotificationDetails}
                       notification={notification}
                       onClickNotification={this.handleClickNotification}
+                      onClickCircle={this.handleReadNotification}
                       shortDate={this.shortDate}
                       user={props.user}
                     />

--- a/frontend/src/css/NotificationWall.styl
+++ b/frontend/src/css/NotificationWall.styl
@@ -68,13 +68,17 @@
           overflow hidden
           font-weight bold
       &__circle
+        font-size wallCircleSize
+        transition 300ms font-size color
+        color lightBlue
+        margin -20px -10px
+        padding 20px 10px
+        &:hover
+            filter brightness(0.7)
         &__wrapper
           margin 0
           min-width 1em
           text-align center
-        font-size 8px
-        transition 300ms font-size color
-        color lightBlue
       &.itemRead
         color lightDarkGrey
         background-color offWhite

--- a/functionnal_tests/cypress/integration/notification_wall/mark_as_read_spec.js
+++ b/functionnal_tests/cypress/integration/notification_wall/mark_as_read_spec.js
@@ -18,18 +18,17 @@ describe('Notification Wall', () => {
     cy.cancelXHR()
   })
 
-  it('should mark the notification as read on click', () => {
-    cy.get('.notification__list__item').get('.notification__list__item__circle').first().click()
-    cy.get('.notification__header__title').contains('Notifications').should('not.be.visible')
-    cy.get('.notificationButton').click()
+  it('should mark the notification as read after click on the circle', () => {
+    cy.get('.notification__list__item__circle').first().click()
+    cy.get('.notificationButton__notification').should('not.be.visible')
     cy.get('.notification__list__item').first().should('have.class', 'itemRead')
   })
 
-  it('should have the Mark All As Read button', () => {
+  it('should have the `Mark All As Read` button', () => {
     cy.get(markAllAsReadButton).should('be.visible')
   })
 
-  it('should mark all notifications as read when click at the Mark All As Read button', () => {
+  it('should mark all notifications as read after click on the `Mark All As Read` button', () => {
     cy.get(markAllAsReadButton).click()
     cy.get('.notification__list__item__circle').should('not.exist')
   })

--- a/functionnal_tests/cypress/integration/notification_wall/mark_as_read_spec.js
+++ b/functionnal_tests/cypress/integration/notification_wall/mark_as_read_spec.js
@@ -3,12 +3,9 @@ import { PAGES } from '../../support/urls_commands'
 const markAllAsReadButton = '[data-cy=markAllAsReadButton]'
 
 describe('Notification Wall', () => {
-  before(function () {
+  beforeEach(function () {
     cy.resetDB()
     cy.setupBaseDB()
-  })
-
-  beforeEach(function () {
     cy.loginAs('users')
     cy.visitPage({ pageName: PAGES.HOME })
     cy.get('.notificationButton').click()
@@ -16,6 +13,14 @@ describe('Notification Wall', () => {
 
   afterEach(function () {
     cy.cancelXHR()
+  })
+
+  it('should mark the notification as read after click on it', () => {
+    cy.get('.notification__list__item').first().click()
+    cy.get('.notification__list__item').should('not.be.visible')
+    cy.get('.notificationButton').click()
+    cy.get('.notificationButton__notification').should('not.be.visible')
+    cy.get('.notification__list__item').first().should('have.class', 'itemRead')
   })
 
   it('should mark the notification as read after click on the circle', () => {


### PR DESCRIPTION
<!-- Here, you can write a short summary of what the pull request brings. If a related issue exists, please reference it here -->

Issue #3361

Add a handle for a click on the notification circle (see issue)

Behavior for group notification -> Open the group and read put everything as read

This PR doesn't implement any tooltip. My thought was "we got this button/action on every items, if we put a tooltip on each, the user will be overwhelmed".

## Checkpoints

<!-- These points must be checked before merging. Please don't edit them out. -->

**For developers**

- [x] If relevant, manual tests have been done to ensure the stability of the whole application and that the involved feature works
- [x] The original issue is up to date w.r.t the latest discussions and contains a short summary of the implemented solution
- [x] Automated tests covering the feature or the fix, have been written, deemed irrelevant (give the reason), or an issue has been created to implement the test (give the link)
- [x] Make sure that:
  - if there are modifications in the Tracim configuration files (eg. `development.ini`), they are documented in `backend/doc/setting.md`
  - any migration process required for existing instances is documented
  - relevant people for these changes are notified
- [x] Original authors of the features included in a multi-feature branch (maintenance fixes -> develop, security fixes -> develop, …) should be part of the reviewers, especially if you encountered merge conflicts.

**For code reviewers**

- [x] The code is clear enough
- [x] If there are FIXMEs in the code, related issues are mentioned in the FIXME
- [x] If there are TODOs, NOTEs or HACKs in code, the date and the developer initials are present

**For testers**

- [x] Manual, quality tests have been done
