### PR TITLE
fix(file): Avoid computing the preview while uploading a file.

### DIFF
--- a/backend/doc/live_messages.md
+++ b/backend/doc/live_messages.md
@@ -97,7 +97,7 @@ Each entry in fields is a subset of the corresponding HTTP API structure.
 }
 ```
 
-### content/thread, content/html-document, content/folder (same as TextBaseContentSchema in API)
+### content/thread, content/html-document, content/folder (same as ContentSchema in API)
 
 ```
 {
@@ -125,7 +125,7 @@ Each entry in fields is a subset of the corresponding HTTP API structure.
 }
 ```
 
-### content/file (same as FileContentSchema in API)
+### content/file, content/kanban (same as FileContentSchema in API)
 
 ```
 {
@@ -150,11 +150,8 @@ Each entry in fields is a subset of the corresponding HTTP API structure.
      "current_revision_type": "edition",
     "content_type": "html-document",
      "raw_content": "Hello, world",
-     "page_nb": 1,
      "mimetype": "text/plain",
      "size": 120,
-     "has_pdf_preview": true,
-     "has_html_preview": false
 }
 ```
 ### content/comment (same as CommentSchema in API)

--- a/backend/tracim_backend/models/context_models.py
+++ b/backend/tracim_backend/models/context_models.py
@@ -607,7 +607,6 @@ class ContentFilter(object):
         show_active: Optional[int] = 1,
         content_type: Optional[str] = None,
         label: Optional[str] = None,
-        page_nb: Optional[int] = None,
         limit: Optional[int] = None,
         namespaces_filter: Optional[str] = None,
         sort: Optional[ContentSortOrder] = None,
@@ -622,7 +621,6 @@ class ContentFilter(object):
         self.show_deleted = bool(show_deleted)
         self.show_active = bool(show_active)
         self.limit = limit
-        self.page_nb = page_nb
         self.label = label
         self.content_type = content_type
         self.sort = sort or ContentSortOrder.LABEL_ASC

--- a/backend/tracim_backend/views/core_api/schemas.py
+++ b/backend/tracim_backend/views/core_api/schemas.py
@@ -1786,17 +1786,11 @@ class ContentSchema(ContentDigestSchema):
     )
 
 
-class FileInfoAbstractSchema(marshmallow.Schema):
+class PreviewInfoSchema(marshmallow.Schema):
+    content_id = marshmallow.fields.Int(example=6, validate=strictly_positive_int_validator)
+    revision_id = marshmallow.fields.Int(example=12, validate=strictly_positive_int_validator)
     page_nb = marshmallow.fields.Int(
         description="number of pages, return null value if unaivalable", example=1, allow_none=True
-    )
-    mimetype = StrippedString(
-        description="file content mimetype", example="image/jpeg", required=True
-    )
-    size = marshmallow.fields.Int(
-        description="file size in byte, return null value if unaivalable",
-        example=1024,
-        allow_none=True,
     )
     has_pdf_preview = marshmallow.fields.Bool(
         description="true if a pdf preview is available or false", example=True
@@ -1806,8 +1800,15 @@ class FileInfoAbstractSchema(marshmallow.Schema):
     )
 
 
-class FileContentSchema(ContentSchema, FileInfoAbstractSchema):
-    pass
+class FileContentSchema(ContentSchema):
+    mimetype = StrippedString(
+        description="file content mimetype", example="image/jpeg", required=True
+    )
+    size = marshmallow.fields.Int(
+        description="file size in byte, return null value if unavailable",
+        example=1024,
+        allow_none=True,
+    )
 
 
 #####
@@ -1839,8 +1840,15 @@ class RevisionPageSchema(BasePaginatedSchemaPage):
     items = marshmallow.fields.Nested(RevisionSchema(many=True))
 
 
-class FileRevisionSchema(RevisionSchema, FileInfoAbstractSchema):
-    pass
+class FileRevisionSchema(RevisionSchema):
+    mimetype = StrippedString(
+        description="file content mimetype", example="image/jpeg", required=True
+    )
+    size = marshmallow.fields.Int(
+        description="file size in byte, return null value if unaivalable",
+        example=1024,
+        allow_none=True,
+    )
 
 
 class FileRevisionPageSchema(BasePaginatedSchemaPage):

--- a/frontend_app_file/src/container/File.jsx
+++ b/frontend_app_file/src/container/File.jsx
@@ -44,7 +44,8 @@ import {
   FAVORITE_STATE,
   PopinFixedRightPartContent,
   sendGlobalFlashMessage,
-  TagList
+  TagList,
+  getFileRevisionPreviewInfo
 } from 'tracim_frontend_lib'
 import { isVideoMimeTypeAndIsAllowed, DISALLOWED_VIDEO_MIME_TYPE_LIST } from '../helper.js'
 import {
@@ -96,7 +97,14 @@ export class File extends React.Component {
       editionAuthor: '',
       invalidMentionList: [],
       showInvalidMentionPopupInComment: false,
-      translationTargetLanguageCode: param.loggedUser.lang
+      translationTargetLanguageCode: param.loggedUser.lang,
+      previewInfo: {
+        has_jpeg_preview: false,
+        has_pdf_preview: false,
+        content_id: param.content.content_id,
+        revision_id: param.content.current_revision_id,
+        page_nb: 1
+      }
     }
     this.refContentLeftTop = React.createRef()
     this.sessionClientToken = getOrCreateSessionClientToken()
@@ -160,11 +168,7 @@ export class File extends React.Component {
     const filenameNoExtension = removeExtensionOfFilename(data.fields.content.filename)
     const newContentObject = {
       ...state.content,
-      ...data.fields.content,
-      previewUrl: buildFilePreviewUrl(state.config.apiUrl, state.content.workspace_id, data.fields.content.content_id, data.fields.content.current_revision_id, filenameNoExtension, 1, 500, 500),
-      lightboxUrlList: (new Array(data.fields.content.page_nb)).fill(null).map((n, i) => i + 1).map(pageNb => // create an array [1..revision.page_nb]
-        buildFilePreviewUrl(state.config.apiUrl, state.content.workspace_id, data.fields.content.content_id, data.fields.content.current_revision_id, filenameNoExtension, pageNb, 1920, 1080)
-      )
+      ...data.fields.content
     }
 
     this.setState(prev => ({
@@ -188,14 +192,15 @@ export class File extends React.Component {
     if (!isTlmAboutCurrentContent) return
 
     const clientToken = this.sessionClientToken
+    const newContentObject = {
+      ...state.content,
+      ...data.fields.content
+    }
     this.setState(prev => ({
       content: clientToken === data.fields.client_token
-        ? { ...prev.content, ...data.fields.content }
+        ? newContentObject
         : prev.content,
-      newContent: {
-        ...prev.content,
-        ...data.fields.content
-      },
+      newContent: newContentObject,
       editionAuthor: data.fields.author.public_name,
       showRefreshWarning: clientToken !== data.fields.client_token,
       mode: clientToken === data.fields.client_token ? APP_FEATURE_MODE.VIEW : prev.mode
@@ -208,15 +213,15 @@ export class File extends React.Component {
     this.props.loadFavoriteContentList(this.state.loggedUser, this.setState.bind(this))
   }
 
-  async updateTimelineAndContent (pageToLoad = null) {
+  async updateTimelineAndContent () {
     const { props } = this
-    this.loadContent(pageToLoad)
+    this.loadContent()
     props.loadTimeline(getFileRevision, this.state.content)
 
     if (this.state.config.workspace.downloadEnabled) this.loadShareLinkList()
   }
 
-  componentDidUpdate (prevProps, prevState) {
+  async componentDidUpdate (prevProps, prevState) {
     const { state } = this
 
     // console.log('%c<File> did update', `color: ${this.state.config.hexcolor}`, prevState, state)
@@ -224,7 +229,19 @@ export class File extends React.Component {
 
     if (prevState.content.content_id !== state.content.content_id) {
       this.setState({ fileCurrentPage: 1 })
-      this.updateTimelineAndContent(1)
+      this.updateTimelineAndContent()
+    } else if (prevState.content.current_revision_id !== state.content.current_revision_id) {
+      this.setState({ fileCurrentPage: 1 })
+      // User selected a revision in the timeline, update the preview info to get the right page number
+      const previewInfoResponse = await handleFetchResult(
+        await getFileRevisionPreviewInfo(
+          state.config.apiUrl,
+          state.content.workspace_id,
+          state.content.content_id,
+          state.content.current_revision_id
+        )
+      )
+      this.setState({ previewInfo: previewInfoResponse.body })
     }
 
     if (prevState.timelineWysiwyg && !state.timelineWysiwyg) tinymceRemove('#wysiwygTimelineComment')
@@ -246,34 +263,33 @@ export class File extends React.Component {
     }
   }
 
-  loadContent = async (pageToLoad = null) => {
+  loadContent = async () => {
     const { state, props } = this
 
     // RJ - 2021-08-07 the state is set before the await, and is therefore not redundant
     // with the setState at the end of the function
     this.setState({ loadingContent: true })
     const response = await handleFetchResult(await getFileContent(state.config.apiUrl, state.content.workspace_id, state.content.content_id))
-
+    const content = response.body
     switch (response.apiResponse.status) {
       case 200: {
+        const previewInfoResponse = await handleFetchResult(
+          await getFileRevisionPreviewInfo(
+            state.config.apiUrl,
+            content.workspace_id,
+            content.content_id,
+            content.current_revision_id
+          )
+        )
         const filenameNoExtension = removeExtensionOfFilename(response.body.filename)
-        const pageForPreview = pageToLoad || state.fileCurrentPage
         this.setState({
           loadingContent: false,
-          content: {
-            ...response.body,
-            filenameNoExtension: filenameNoExtension,
-            // FIXME - b.l - refactor urls
-            previewUrl: `${state.config.apiUrl}/workspaces/${state.content.workspace_id}/files/${state.content.content_id}/revisions/${response.body.current_revision_id}/preview/jpg/500x500/${filenameNoExtension + '.jpg'}?page=${pageForPreview}&revision_id=${response.body.current_revision_id}`,
-            lightboxUrlList: (new Array(response.body.page_nb)).fill('').map((n, i) =>
-              // FIXME - b.l - refactor urls
-              `${state.config.apiUrl}/workspaces/${state.content.workspace_id}/files/${state.content.content_id}/revisions/${response.body.current_revision_id}/preview/jpg/1920x1080/${filenameNoExtension + '.jpg'}?page=${i + 1}`
-            )
-          },
-          mode: APP_FEATURE_MODE.VIEW
+          content,
+          mode: APP_FEATURE_MODE.VIEW,
+          previewInfo: previewInfoResponse.body
         })
         this.setHeadTitle(filenameNoExtension)
-        this.buildBreadcrumbs(response.body)
+        this.buildBreadcrumbs(content)
         break
       }
       default:
@@ -497,23 +513,14 @@ export class File extends React.Component {
 
     if (state.mode === APP_FEATURE_MODE.VIEW && isLastRevision) return
 
-    const filenameNoExtension = removeExtensionOfFilename(revision.filename)
-
     this.setState(prev => ({
       content: {
         ...prev.content,
         ...revision,
         workspace_id: state.content.workspace_id, // don't overrides workspace_id because if file has been moved to a different workspace, workspace_id will change and break image urls
-        filenameNoExtension: filenameNoExtension,
         current_revision_id: revision.revision_id,
-        contentFull: null,
         is_archived: prev.is_archived, // archived and delete should always be taken from last version
-        is_deleted: prev.is_deleted,
-        // use state.content.workspace_id instead of revision.workspace_id because if file has been moved to a different workspace, workspace_id will change and break image urls
-        previewUrl: buildFilePreviewUrl(state.config.apiUrl, state.content.workspace_id, revision.content_id, revision.revision_id, filenameNoExtension, 1, 500, 500),
-        lightboxUrlList: (new Array(revision.page_nb)).fill(null).map((n, i) => i + 1).map(pageNb => // create an array [1..revision.page_nb]
-          buildFilePreviewUrl(state.config.apiUrl, state.content.workspace_id, revision.content_id, revision.revision_id, filenameNoExtension, pageNb, 1920, 1080)
-        )
+        is_deleted: prev.is_deleted
       },
       fileCurrentPage: 1, // always set to first page on revision switch
       mode: APP_FEATURE_MODE.REVISION
@@ -525,7 +532,7 @@ export class File extends React.Component {
       fileCurrentPage: 1,
       mode: APP_FEATURE_MODE.VIEW
     })
-    this.loadContent(1)
+    this.loadContent()
   }
 
   handleChangeFile = newFile => {
@@ -616,16 +623,12 @@ export class File extends React.Component {
 
     if (!['previous', 'next'].includes(previousNext)) return
     if (previousNext === 'previous' && state.fileCurrentPage === 0) return
-    if (previousNext === 'next' && state.fileCurrentPage > state.content.page_nb) return
+    if (previousNext === 'next' && state.fileCurrentPage > state.previewInfo.page_nb) return
 
     const nextPageNumber = previousNext === 'previous' ? state.fileCurrentPage - 1 : state.fileCurrentPage + 1
 
     this.setState(prev => ({
-      fileCurrentPage: nextPageNumber,
-      content: {
-        ...prev.content,
-        previewUrl: buildFilePreviewUrl(state.config.apiUrl, state.content.workspace_id, state.content.content_id, state.content.current_revision_id, state.content.filenameNoExtension, nextPageNumber, 500, 500)
-      }
+      fileCurrentPage: nextPageNumber
     }))
   }
 
@@ -876,7 +879,7 @@ export class File extends React.Component {
             color={state.config.hexcolor}
             fileType={state.content.mimetype}
             fileSize={displayFileSize(state.content.size)}
-            filePageNb={state.content.page_nb}
+            filePageNb={state.previewInfo.page_nb}
             activesShares={state.content.actives_shares}
             creationDateFormattedWithTime={(new Date(state.content.created)).toLocaleString(props.i18n.language, { day: '2-digit', month: '2-digit', year: 'numeric' })}
             creationDateFormatted={(new Date(state.content.created)).toLocaleString(props.i18n.language)}
@@ -990,6 +993,31 @@ export class File extends React.Component {
     const revisionList = props.timeline.filter(t => t.timelineType === 'revision')
     const contentVersionNumber = (revisionList.find(t => t.revision_id === state.content.current_revision_id) || { version_number: 1 }).version_number
     const lastVersionNumber = (revisionList[revisionList.length - 1] || { version_number: 1 }).version_number
+    const filenameWithoutExtension = state.loadingContent ? '' : removeExtensionOfFilename(state.content.filename)
+    const previewUrl = buildFilePreviewUrl(
+      state.config.apiUrl,
+      state.content.workspace_id,
+      state.content.content_id,
+      state.content.current_revision_id,
+      filenameWithoutExtension,
+      state.fileCurrentPage,
+      500,
+      500
+    )
+    const lightboxUrlList = (new Array(state.previewInfo.page_nb))
+      .fill(null)
+      .map((n, index) => // create an array [1..revision.page_nb]
+        buildFilePreviewUrl(
+          state.config.apiUrl,
+          state.content.workspace_id,
+          state.content.content_id,
+          state.content.current_revision_id,
+          filenameWithoutExtension,
+          index + 1,
+          1920,
+          1080
+        )
+      )
 
     return (
       <PopinFixed
@@ -1057,13 +1085,13 @@ export class File extends React.Component {
               icon: 'far fa-file',
               label: props.t('Download current page as PDF'),
               downloadLink: this.getDownloadPdfPageUrl(state),
-              showAction: state.content.has_pdf_preview,
+              showAction: state.previewInfo.has_pdf_preview,
               dataCy: 'popinListItem__downloadPageAsPdf'
             }, {
               icon: 'far fa-file-pdf',
               label: props.t('Download as PDF'),
               downloadLink: this.getDownloadPdfFullUrl(state),
-              showAction: state.content.has_pdf_preview,
+              showAction: state.previewInfo.has_pdf_preview,
               dataCy: 'popinListItem__downloadAsPdf'
             }, {
               icon: 'fas fa-download',
@@ -1099,9 +1127,9 @@ export class File extends React.Component {
             mode={state.mode}
             customColor={state.config.hexcolor}
             loggedUser={state.loggedUser}
-            previewUrl={state.content.previewUrl ? state.content.previewUrl : ''}
-            isJpegAvailable={state.content.has_jpeg_preview}
-            filePageNb={state.content.page_nb}
+            previewUrl={previewUrl}
+            isJpegAvailable={state.previewInfo.has_jpeg_preview}
+            filePageNb={state.previewInfo.page_nb}
             fileCurrentPage={state.fileCurrentPage}
             mimeType={state.content.mimetype}
             isArchived={state.content.is_archived}
@@ -1111,10 +1139,10 @@ export class File extends React.Component {
             onClickRestoreArchived={this.handleClickRestoreArchive}
             onClickRestoreDeleted={this.handleClickRestoreDelete}
             downloadRawUrl={this.getDownloadRawUrl(state)}
-            isPdfAvailable={state.content.has_pdf_preview}
+            isPdfAvailable={state.previewInfo.has_pdf_preview}
             downloadPdfPageUrl={this.getDownloadPdfPageUrl(state)}
             downloadPdfFullUrl={this.getDownloadPdfFullUrl(state)}
-            lightboxUrlList={state.content.lightboxUrlList}
+            lightboxUrlList={lightboxUrlList}
             onChangeFile={this.handleChangeFile}
             onClickDropzoneCancel={this.handleClickDropzoneCancel}
             onClickDropzoneValidate={this.handleClickDropzoneValidate}

--- a/frontend_app_file/test/component/File.spec.js
+++ b/frontend_app_file/test/component/File.spec.js
@@ -117,7 +117,6 @@ describe('<File />', () => {
                 label: 'New File',
                 slug: 'newFile',
                 created: '2020-05-20T12:15:57Z',
-                page_nb: 3,
                 modified: '2020-05-20T12:15:57Z',
                 mimetype: 'image/jpeg'
               },
@@ -138,15 +137,6 @@ describe('<File />', () => {
           })
           it('should have the new created date', () => {
             expect(wrapper.state('newContent').created).to.equal(tlmData.fields.content.created)
-          })
-          it('should have the new page_nb', () => {
-            expect(wrapper.state('newContent').page_nb).to.equal(tlmData.fields.content.page_nb)
-          })
-          it('should have the new previewUrl', () => {
-            expect(wrapper.state('newContent').previewUrl).to.equal(debug.config.apiUrl + '/workspaces/0/files/0/revisions/137/preview/jpg/500x500/New%20File.jpg?page=1')
-          })
-          it('should have 3 preview pages', () => {
-            expect(wrapper.state('newContent').lightboxUrlList.length).to.equal(3)
           })
         })
 

--- a/frontend_app_gallery/src/container/Gallery.jsx
+++ b/frontend_app_gallery/src/container/Gallery.jsx
@@ -27,7 +27,8 @@ import {
   TLM_SUB_TYPE as TLM_ST,
   BREADCRUMBS_TYPE,
   PAGE,
-  ROLE
+  ROLE,
+  getFileRevisionPreviewInfo
 } from 'tracim_frontend_lib'
 import Carousel from '../component/Carousel.jsx'
 import { DIRECTION, buildRawFileUrl } from '../helper.js'
@@ -128,16 +129,16 @@ export class Gallery extends React.Component {
     this.updateBreadcrumbsAndTitle(data.fields.workspace.label, state.folderDetail)
   }
 
-  handleContentCreatedOrUndeleted = data => {
+  handleContentCreatedOrUndeleted = async data => {
     if (this.liveMessageNotRelevant(data, this.state)) return
 
-    const preview = this.buildPreview(data.fields.content)
+    const preview = await this.buildPreview(data.fields.content)
     if (preview) {
       this.setNewPicturesPreviews([preview, ...this.state.imagePreviewList].sort(this.sortPreviews))
     }
   }
 
-  handleContentModified = data => {
+  handleContentModified = async data => {
     const { state } = this
     if (this.liveMessageNotRelevant(data, state)) {
       // INFO - GM - 2020-07-20 - The if below covers the move functionality.
@@ -156,7 +157,7 @@ export class Gallery extends React.Component {
       image => image.contentId !== data.fields.content.content_id
     )
 
-    const preview = this.buildPreview(data.fields.content)
+    const preview = await this.buildPreview(data.fields.content)
     if (preview) {
       // RJ - 2020-06-15 - NOTE
       // Unlikely, but a picture could be replaced by a file of another type
@@ -415,10 +416,17 @@ export class Gallery extends React.Component {
     }
   }
 
-  buildPreview = (file) => {
-    if (!file.has_jpeg_preview) return false
-
+  buildPreview = async (file) => {
     const { state } = this
+    const previewInfoResponse = await handleFetchResult(
+      await getFileRevisionPreviewInfo(
+        state.config.apiUrl,
+        file.workspace_id,
+        file.content_id,
+        file.current_revision_id
+      )
+    )
+    if (!previewInfoResponse.body.has_jpeg_preview) return false
 
     const filenameNoExtension = removeExtensionOfFilename(file.filename)
 
@@ -444,19 +452,15 @@ export class Gallery extends React.Component {
       125
     )
 
-    const lightBoxUrlList = (
-      new Array(file.page_nb)
-        .fill('')
-        .map((n, j) => buildFilePreviewUrl(
-          state.config.apiUrl,
-          state.config.appConfig.workspaceId,
-          file.content_id,
-          file.current_revision_id,
-          filenameNoExtension,
-          j + 1,
-          1920,
-          1920
-        ))
+    const lightBoxUrl = buildFilePreviewUrl(
+      state.config.apiUrl,
+      state.config.appConfig.workspaceId,
+      file.content_id,
+      file.current_revision_id,
+      filenameNoExtension,
+      1,
+      1920,
+      1920
     )
 
     const rawFileUrl = buildRawFileUrl(
@@ -471,7 +475,7 @@ export class Gallery extends React.Component {
       label: file.label,
       src: previewUrl,
       fileName: file.filename,
-      lightBoxUrlList,
+      lightBoxUrl,
       previewUrlForThumbnail,
       rotationAngle: 0,
       rawFileUrl
@@ -489,7 +493,7 @@ export class Gallery extends React.Component {
       )
 
       if (fetchFileContent.apiResponse.status === 200) {
-        return this.buildPreview(fetchFileContent.body)
+        return await this.buildPreview(fetchFileContent.body)
       }
 
       sendGlobalFlashMessage(this.props.t('Error while loading file preview'))
@@ -551,8 +555,8 @@ export class Gallery extends React.Component {
 
     if (state.imagePreviewList.length <= 1) return
 
-    if (state.displayedPictureIndex === 0) return state.imagePreviewList[state.imagePreviewList.length - 1].lightBoxUrlList[0]
-    return state.imagePreviewList[state.displayedPictureIndex - 1].lightBoxUrlList[0]
+    if (state.displayedPictureIndex === 0) return state.imagePreviewList[state.imagePreviewList.length - 1].lightBoxUrl
+    return state.imagePreviewList[state.displayedPictureIndex - 1].lightBoxUrl
   }
 
   getNextImageUrl = () => {
@@ -560,8 +564,8 @@ export class Gallery extends React.Component {
 
     if (state.imagePreviewList.length <= 1) return
 
-    if (state.displayedPictureIndex === state.imagePreviewList.length - 1) return state.imagePreviewList[0].lightBoxUrlList[0]
-    return state.imagePreviewList[state.displayedPictureIndex + 1].lightBoxUrlList[0]
+    if (state.displayedPictureIndex === state.imagePreviewList.length - 1) return state.imagePreviewList[0].lightBoxUrl
+    return state.imagePreviewList[state.displayedPictureIndex + 1].lightBoxUrl
   }
 
   handleCarouselPositionChange = (pictureIndex) => {
@@ -788,7 +792,7 @@ export class Gallery extends React.Component {
                 <div className='gallery__mouse__listener' onMouseMove={this.handleMouseMove}>
                   <ReactImageLightbox
                     prevSrc={this.getPreviousImageUrl()}
-                    mainSrc={this.displayedPicture().lightBoxUrlList[0]}
+                    mainSrc={this.displayedPicture().lightBoxUrl}
                     nextSrc={this.getNextImageUrl()}
                     onCloseRequest={this.handleClickHideImageRaw}
                     onMovePrevRequest={() => { this.handleClickPreviousNextPage(DIRECTION.LEFT) }}

--- a/frontend_app_gallery/test/apiMock.js
+++ b/frontend_app_gallery/test/apiMock.js
@@ -27,8 +27,35 @@ const mockGetFolderDetailDetail200 = (apiUrl, workspaceId, folderId, folderName,
     })
 }
 
+const mockGetFileRevisionPreviewInfo200 = (apiUrl, workspaceId, contentId, revisionId) => {
+  return nock(apiUrl)
+    .get(`/workspaces/${workspaceId}/files/${contentId}/revisions/${revisionId}/preview_info`)
+    .reply(200, {
+      page_nb: 1,
+      has_jpeg_preview: true,
+      has_pdf_preview: true,
+      content_id: contentId,
+      revision_id: revisionId
+    })
+}
+
+const mockGetWorkspaceContentList = (apiUrl, workspaceId, parentId = 0) => {
+  return nock(apiUrl)
+    .get(`/workspaces/${workspaceId}/contents?parent_ids=${parentId}`)
+    .reply(200, {
+      has_next: false,
+      has_previous: false,
+      items: [],
+      per_page: 10,
+      previous_page_token: null,
+      next_page_token: null
+    })
+}
+
 export {
   mockGetContents200,
   mockGetWorkspaceDetail200,
-  mockGetFolderDetailDetail200
+  mockGetFolderDetailDetail200,
+  mockGetFileRevisionPreviewInfo200,
+  mockGetWorkspaceContentList
 }

--- a/frontend_app_gallery/test/component/Gallery.spec.js
+++ b/frontend_app_gallery/test/component/Gallery.spec.js
@@ -7,7 +7,8 @@ import { defaultDebug, PAGE } from 'tracim_frontend_lib'
 import {
   mockGetContents200,
   mockGetWorkspaceDetail200,
-  mockGetFolderDetailDetail200
+  mockGetFolderDetailDetail200,
+  mockGetWorkspaceContentList
 } from '../apiMock.js'
 
 describe('<Gallery />', () => {
@@ -80,9 +81,7 @@ describe('<Gallery />', () => {
         src: 'mock.com/3.jpg',
         contentId: 3,
         fileName: 'imageThree',
-        lightBoxUrlList: [
-          'mock.com/big/3.jpg'
-        ],
+        lightBoxUrl: 'mock.com/big/3.jpg',
         previewUrlForThumbnail: [
           'mock.com/small/3.jpg'
         ],
@@ -105,11 +104,11 @@ describe('<Gallery />', () => {
     describe('getPreviousImageUrl()', () => {
       it('should return the previous imagePreview when filSelected > 0', () => {
         wrapper.setState({ displayedPictureIndex: 1 })
-        expect(wrapper.instance().getPreviousImageUrl()).to.equal(stateMock.imagePreviewList[0].lightBoxUrlList[0])
+        expect(wrapper.instance().getPreviousImageUrl()).to.equal(stateMock.imagePreviewList[0].lightBoxUrl)
       })
       it('should return the last imagePreview when displayedPictureIndex === 0', () => {
         wrapper.setState({ displayedPictureIndex: 0 })
-        expect(wrapper.instance().getPreviousImageUrl()).to.equal(stateMock.imagePreviewList[stateMock.imagePreviewList.length - 1].lightBoxUrlList[0])
+        expect(wrapper.instance().getPreviousImageUrl()).to.equal(stateMock.imagePreviewList[stateMock.imagePreviewList.length - 1].lightBoxUrl)
       })
       it('should return undefined when imagePreviewList length <= 1', () => {
         wrapper.setState({ imagePreviewList: [] })
@@ -121,11 +120,11 @@ describe('<Gallery />', () => {
     describe('getNextImageUrl()', () => {
       it('should return the next imagePreview when filSelected < imagePreviewList.length', () => {
         wrapper.setState({ displayedPictureIndex: 1 })
-        expect(wrapper.instance().getNextImageUrl()).to.equal(stateMock.imagePreviewList[2].lightBoxUrlList[0])
+        expect(wrapper.instance().getNextImageUrl()).to.equal(stateMock.imagePreviewList[2].lightBoxUrl)
       })
       it('should return the first imagePreview when filSelected === imagePreviewList.length-1', () => {
         wrapper.setState({ displayedPictureIndex: stateMock.imagePreviewList.length - 1 })
-        expect(wrapper.instance().getNextImageUrl()).to.equal(stateMock.imagePreviewList[0].lightBoxUrlList[0])
+        expect(wrapper.instance().getNextImageUrl()).to.equal(stateMock.imagePreviewList[0].lightBoxUrl)
       })
       it('should return undefined when imagePreviewList length <= 1', () => {
         wrapper.setState({ imagePreviewList: [] })
@@ -246,6 +245,7 @@ describe('<Gallery />', () => {
 
     describe('buildBreadcrumbs()', () => {
       it('should build the correct breadcrumbsList when empty workspace gallery', () => {
+        mockGetWorkspaceContentList(props.data.config.apiUrl, 0, 0)
         wrapper.setState({ imagePreviewList: [], folderId: null })
         wrapper.instance().buildBreadcrumbs(stateMock.content.workspaceLabel, { fileName: '', folderParentIdList: [] }, true)
         expect(wrapper.state().breadcrumbsList.length).to.equal(2)
@@ -254,6 +254,7 @@ describe('<Gallery />', () => {
       })
 
       it('should build the correct breadcrumbsList when workspace gallery', () => {
+        mockGetWorkspaceContentList(props.data.config.apiUrl, 0, 0)
         wrapper.setState({ imagePreviewList: stateMock.imagePreviewList, folderId: null })
         wrapper.instance().buildBreadcrumbs(stateMock.content.workspaceLabel, { fileName: '', folderParentIdList: [] }, false)
         expect(wrapper.state().breadcrumbsList.length).to.equal(3)

--- a/frontend_app_gallery/test/setup.js
+++ b/frontend_app_gallery/test/setup.js
@@ -20,6 +20,7 @@ if (!global.window && !global.document) {
   global.window = window
   global.document = window.document
   global.navigator = window.navigator
+  global.FormData = window.FormData
   global.GLOBAL_dispatchEvent = () => {}
   global.GLOBAL_primaryColor = '#aaaaaa'
   const nodeCrypto = require('crypto')

--- a/frontend_lib/src/action.async.js
+++ b/frontend_lib/src/action.async.js
@@ -241,3 +241,6 @@ export const postRawFileContent = (
   if (parentId) formData.append('parent_id', parentId)
   return baseFetch('POST', `${apiUrl}/workspaces/${workspaceId}/files`, formData)
 }
+
+export const getFileRevisionPreviewInfo = (apiUrl, workspaceId, contentId, revisionId) =>
+  baseFetch('GET', `${apiUrl}/workspaces/${workspaceId}/files/${contentId}/revisions/${revisionId}/preview_info`)

--- a/frontend_lib/src/index.js
+++ b/frontend_lib/src/index.js
@@ -224,7 +224,8 @@ import {
   getGenericWorkspaceContent,
   getRawFileContent,
   putRawFileContent,
-  postRawFileContent
+  postRawFileContent,
+  getFileRevisionPreviewInfo
 } from './action.async.js'
 
 const customEventReducer = ({ detail: { type, data } }) => {
@@ -459,6 +460,7 @@ export {
   getRawFileContent,
   putRawFileContent,
   postRawFileContent,
+  getFileRevisionPreviewInfo,
   tinymceRemove,
   Popover,
   getBrowserLang

--- a/functionnal_tests/cypress/integration/app_file/switch_between_file_spec.js
+++ b/functionnal_tests/cypress/integration/app_file/switch_between_file_spec.js
@@ -37,10 +37,10 @@ describe('App File', () => {
           params: { contentId: secondContentId }
         })
 
+        cy.contains('.breadcrumbs__item', fileTitle_2).should('be.visible')
+
         cy.get('[data-cy="revision_data_2"]')
           .click()
-
-        cy.contains('.breadcrumbs__item', fileTitle_2)
 
         cy.get('[data-cy="appFileLastVersionBtn"]')
           .should('be.visible')


### PR DESCRIPTION
Done by moving preview-related infos to a specific endpoint.
And removing them from the generated TLM (content.modified).

See #5495

-------

<!-- Here, you can write a short summary of what the pull request brings. If a related issue exists, please reference it here -->

## Checkpoints

<!-- These points must be checked before merging. Please don't edit them out. -->

**For developers**

- [x] If relevant, manual tests have been done to ensure the stability of the whole application and that the involved feature works
- [x] The original issue is up to date w.r.t the latest discussions and contains a short summary of the implemented solution
- [x] Automated tests covering the feature or the fix, have been written, deemed irrelevant (give the reason), or an issue has been created to implement the test (give the link)
- [x] Make sure that:
  - if there are modifications in the Tracim configuration files (eg. `development.ini`), they are documented in `backend/doc/setting.md`
  - any migration process required for existing instances is documented
  - relevant people for these changes are notified
- [x] Original authors of the features included in a multi-feature branch (maintenance fixes -> develop, security fixes -> develop, …) should be part of the reviewers, especially if you encountered merge conflicts.

**For code reviewers**

- [x] The code is clear enough
- [x] If there are FIXMEs in the code, related issues are mentioned in the FIXME
- [x] If there are TODOs, NOTEs or HACKs in code, the date and the developer initials are present

**For testers**

- [x] Manual, quality tests have been done

Hints for testing: play with the file and gallery apps (as they were both impacted), the fix itself can be checked by uploading the same file with the code on develop and this branch, then notice the time the upload popup stays open with `99%` progress. Good candidate files are office files as they take a relatively long time to be previewed.