### PR TITLE
Allow anonymous smtp authentication

### DIFF
--- a/backend/development.ini.sample
+++ b/backend/development.ini.sample
@@ -547,14 +547,14 @@ website.usage_conditions =
 # email.notification.smtp.password = your_smtp_password
 
 # anonymous smtp connection: skip user/password login step.
-; email.notification.smtp.anonymous = False
+; email.notification.smtp.authentication = False
 
-# SMTP connection method valid values are:
+# SMTP encryption method valid values are:
 # - default: use smtp encryption using starttls, and unencrypted connection as fallback.
 # - SMTPS: use encrypted connection directly on port like 465
-# - unsecure: use unencrypted connection, use it with caution !
+# - unencrypted: use unencrypted connection, use it with caution !
 # default value: default
-; email.notification.smtp.connection_method = default
+; email.notification.smtp.encryption = default
 
 ### Headers ###
 ; email.notification.from.default_label = Tracim Notifications

--- a/backend/development.ini.sample
+++ b/backend/development.ini.sample
@@ -546,13 +546,14 @@ website.usage_conditions =
 # email.notification.smtp.user = your_smtp_user
 # email.notification.smtp.password = your_smtp_password
 
-# anonymous smtp connection: skip user/password login step.
+# Enable/disable authentification.
+# False mean anonymous smtp connection, it skip user/password login step.
 ; email.notification.smtp.authentication = False
 
 # SMTP encryption method valid values are:
 # - default: use smtp encryption using starttls, and unencrypted connection as fallback.
 # - SMTPS: use encrypted connection directly on port like 465
-# - no: don't use encryption, use it with caution !
+# - unsecure: don't use encryption, use it with caution !
 # default value: default
 ; email.notification.smtp.encryption = default
 

--- a/backend/development.ini.sample
+++ b/backend/development.ini.sample
@@ -546,10 +546,15 @@ website.usage_conditions =
 # email.notification.smtp.user = your_smtp_user
 # email.notification.smtp.password = your_smtp_password
 
-# enable implicit ssl if you are using implicit smtp with encryption port like 465
-# by default, Tracim will try to use explicit smtp encryption using starttls, and unencrypted
-# connection as fallback.
-; email.notification.smtp.use_implicit_ssl = False
+# anonymous smtp connection: skip user/password login step.
+; email.notification.smtp.anonymous = False
+
+# SMTP connection method valid values are:
+# - default: use smtp encryption using starttls, and unencrypted connection as fallback.
+# - SMTPS: use encrypted connection directly on port like 465
+# - unsecure: use unencrypted connection, use it with caution !
+# default value: default
+; email.notification.smtp.connection_method = default
 
 ### Headers ###
 ; email.notification.from.default_label = Tracim Notifications

--- a/backend/development.ini.sample
+++ b/backend/development.ini.sample
@@ -552,7 +552,7 @@ website.usage_conditions =
 # SMTP encryption method valid values are:
 # - default: use smtp encryption using starttls, and unencrypted connection as fallback.
 # - SMTPS: use encrypted connection directly on port like 465
-# - unencrypted: use unencrypted connection, use it with caution !
+# - no: don't use encryption, use it with caution !
 # default value: default
 ; email.notification.smtp.encryption = default
 

--- a/backend/doc/env_settings.md
+++ b/backend/doc/env_settings.md
@@ -39,7 +39,6 @@ Note that you need to activate all applications (`app.enabled` setting) for this
 | TRACIM_USER__CUSTOM_PROPERTIES__JSON_SCHEMA_FILE_PATH                     | user.custom_properties.json_schema_file_path                   | USER__CUSTOM_PROPERTIES__JSON_SCHEMA_FILE_PATH                     |
 | TRACIM_USER__CUSTOM_PROPERTIES__UI_SCHEMA_FILE_PATH                       | user.custom_properties.ui_schema_file_path                     | USER__CUSTOM_PROPERTIES__UI_SCHEMA_FILE_PATH                       |
 | TRACIM_USER__CUSTOM_PROPERTIES__TRANSLATIONS_DIR_PATH                     | user.custom_properties.translations_dir_path                   | USER__CUSTOM_PROPERTIES__TRANSLATIONS_DIR_PATH                     |
-| TRACIM_CALDAV__PRE_FILLED_EVENT__DESCRIPTION_FILE_PATH                    | caldav.pre_filled_event.description_file_path                  | CALDAV__PRE_FILLED_EVENT__DESCRIPTION_FILE_PATH                    |
 | TRACIM_WORKSPACE__ALLOWED_ACCESS_TYPES                                    | workspace.allowed_access_types                                 | WORKSPACE__ALLOWED_ACCESS_TYPES                                    |
 | TRACIM_WORKSPACE__JOIN__MAX_MESSAGES_HISTORY_COUNT                        | workspace.join.max_messages_history_count                      | WORKSPACE__JOIN__MAX_MESSAGES_HISTORY_COUNT                        |
 | TRACIM_KNOWN_MEMBERS__FILTER                                              | known_members.filter                                           | KNOWN_MEMBERS__FILTER                                              |
@@ -98,7 +97,9 @@ Note that you need to activate all applications (`app.enabled` setting) for this
 | TRACIM_EMAIL__NOTIFICATION__SMTP__PORT                                    | email.notification.smtp.port                                   | EMAIL__NOTIFICATION__SMTP__PORT                                    |
 | TRACIM_EMAIL__NOTIFICATION__SMTP__USER                                    | email.notification.smtp.user                                   | EMAIL__NOTIFICATION__SMTP__USER                                    |
 | TRACIM_EMAIL__NOTIFICATION__SMTP__PASSWORD                                | email.notification.smtp.password                               | EMAIL__NOTIFICATION__SMTP__PASSWORD                                |
+| TRACIM_EMAIL__NOTIFICATION__SMTP__AUTHENTICATION                          | email.notification.smtp.authentication                         | EMAIL__NOTIFICATION__SMTP__AUTHENTICATION                          |
 | TRACIM_EMAIL__NOTIFICATION__SMTP__USE_IMPLICIT_SSL                        | email.notification.smtp.use_implicit_ssl                       | EMAIL__NOTIFICATION__SMTP__USE_IMPLICIT_SSL                        |
+| TRACIM_EMAIL__NOTIFICATION__SMTP__ENCRYPTION                              | email.notification.smtp.encryption                             | EMAIL__NOTIFICATION__SMTP__ENCRYPTION                              |
 | TRACIM_EMAIL__REPLY__ACTIVATED                                            | email.reply.activated                                          | EMAIL__REPLY__ACTIVATED                                            |
 | TRACIM_EMAIL__REPLY__IMAP__SERVER                                         | email.reply.imap.server                                        | EMAIL__REPLY__IMAP__SERVER                                         |
 | TRACIM_EMAIL__REPLY__IMAP__PORT                                           | email.reply.imap.port                                          | EMAIL__REPLY__IMAP__PORT                                           |
@@ -155,6 +156,7 @@ Note that you need to activate all applications (`app.enabled` setting) for this
 | TRACIM_CALL__UNANSWERED_TIMEOUT                                           | call.unanswered_timeout                                        | CALL__UNANSWERED_TIMEOUT                                           |
 | TRACIM_CALDAV__RADICALE_PROXY__BASE_URL                                   | caldav.radicale_proxy.base_url                                 | CALDAV__RADICALE_PROXY__BASE_URL                                   |
 | TRACIM_CALDAV__RADICALE__STORAGE__FILESYSTEM_FOLDER                       | caldav.radicale.storage.filesystem_folder                      | CALDAV__RADICALE__STORAGE__FILESYSTEM_FOLDER                       |
+| TRACIM_CALDAV__PRE_FILLED_EVENT__DESCRIPTION_FILE_PATH                    | caldav.pre_filled_event.description_file_path                  | CALDAV__PRE_FILLED_EVENT__DESCRIPTION_FILE_PATH                    |
 | TRACIM_COLLABORATIVE_DOCUMENT_EDITION__SOFTWARE                           | collaborative_document_edition.software                        | COLLABORATIVE_DOCUMENT_EDITION__SOFTWARE                           |
 | TRACIM_COLLABORATIVE_DOCUMENT_EDITION__COLLABORA__BASE_URL                | collaborative_document_edition.collabora.base_url              | COLLABORATIVE_DOCUMENT_EDITION__COLLABORA__BASE_URL                |
 | TRACIM_COLLABORATIVE_DOCUMENT_EDITION__FILE_TEMPLATE_DIR                  | collaborative_document_edition.file_template_dir               | COLLABORATIVE_DOCUMENT_EDITION__FILE_TEMPLATE_DIR                  |

--- a/backend/doc/setting.md
+++ b/backend/doc/setting.md
@@ -245,10 +245,12 @@ To enable mail notification, the smallest config is:
     email.notification.smtp.port = 1025
     email.notification.smtp.user = test_user
     email.notification.smtp.password = just_a_password
-    # active implicit ssl if you are using implicit smtp with encryption port like 465
-    # by default, tracim will try to use explicit smtp encryption using starttls, and unencrypted
-    # connection as fallback.
-    email.notification.smtp.use_implicit_ssl = false
+    # SMTP encryption method valid values are:
+    # - default: use smtp encryption using starttls, and unencrypted connection as fallback.
+    # - SMTPS: use encrypted connection directly on port like 465
+    # - unsecure: don't use encryption, use it with caution !
+    # default value: default
+    email.notification.smtp.encryption = default
 
 Don't forget to set `website.base_url` and `website.title` for the frontend, as some features use them to
 link the frontend in emails.

--- a/backend/tests_configs.ini
+++ b/backend/tests_configs.ini
@@ -148,6 +148,7 @@ email.notification.smtp.server = 127.0.0.1
 email.notification.smtp.port = 1025
 email.notification.smtp.user = test_user
 email.notification.smtp.password = just_a_password
+email.notification.smtp.connect_method = unsecure
 
 
 [functional_ldap_and_internal_test]
@@ -192,6 +193,40 @@ email.notification.smtp.server = 127.0.0.1
 email.notification.smtp.port = 1025
 email.notification.smtp.user = test_user
 email.notification.smtp.password = just_a_password
+email.notification.smtp.connect_method = unsecure
+website.base_url = http://localhost:6543
+
+[mail_test_anonymous]
+app.enabled = contents/thread,contents/file,contents/html-document,contents/folder,upload_permission,share_content
+email.notification.activated = true
+email.notification.from.email = test_user_from+{user_id}@localhost
+email.notification.from.default_label = Tracim Notifications
+email.notification.reply_to.email = test_user_reply+{content_id}@localhost
+email.notification.references.email = test_user_refs+{content_id}@localhost
+# email templates
+email.notification.content_update.template.html = %(here)s/tracim_backend/templates/mail/content_update_body_html.mak
+email.notification.created_account.template.html = %(here)s/tracim_backend/templates/mail/created_account_body_html.mak
+email.notification.reset_password_request.template.html = %(here)s/tracim_backend/templates/mail/reset_password_body_html.mak
+email.notification.share_content_to_emitter.template.html = %(here)s/tracim_backend/templates/mail/shared_content_to_emitter_body_html.mak
+email.notification.share_content_to_receiver.template.html = %(here)s/tracim_backend/templates/mail/shared_content_to_receiver_body_html.mak
+email.notification.upload_permission_to_emitter.template.html = %(here)s/tracim_backend/templates/mail/upload_permission_to_emitter_body_html.mak
+email.notification.upload_permission_to_receiver.template.html = %(here)s/tracim_backend/templates/mail/upload_permission_to_receiver_body_html.mak
+email.notification.new_upload_event.template.html = %(here)s/tracim_backend/templates/mail/new_upload_event_body_html.mak
+# Note: items between { and } are variable names. Do not remove / rename them
+email.notification.content_update.subject = [{website_title}] [{workspace_label}] {content_label} ({content_status_label})
+email.notification.created_account.subject = [{website_title}] Created account
+email.notification.share_content_to_emitter.subject = [{website_title}] You shared "{content_filename}" with {nb_receivers} people
+email.notification.share_content_to_receiver.subject = [{website_title}] {emitter_name} shared the file "{content_filename}" with you
+email.notification.upload_permission_to_emitter.subject = [{website_title}] You invited {nb_receivers} people to upload files on "{workspace_name}"
+email.notification.upload_permission_to_receiver.subject = {emitter_name} invited you to upload files on "{website_title}"
+# processing_mode may be sync or async
+jobs.processing_mode = sync
+email.notification.smtp.server = 127.0.0.1
+email.notification.smtp.port = 1025
+email.notification.smtp.user =
+email.notification.smtp.password =
+email.notification.smtp.anonymous = True
+email.notification.smtp.connect_method = unsecure
 website.base_url = http://localhost:6543
 
 [mail_test_async]
@@ -223,6 +258,7 @@ email.notification.smtp.server = 127.0.0.1
 email.notification.smtp.port = 1025
 email.notification.smtp.user = test_user
 email.notification.smtp.password = just_a_password
+email.notification.smtp.connect_method = unsecure
 website.base_url = http://localhost:6543
 
 [functional_live_test]
@@ -464,6 +500,7 @@ email.notification.smtp.server = 127.0.0.1
 email.notification.smtp.port = 1025
 email.notification.smtp.user = test_user
 email.notification.smtp.password = just_a_password
+email.notification.smtp.connect_method = unsecure
 email.notification.from.email = test_user_from+{user_id}@localhost
 email.notification.from.default_label = Tracim Notifications
 email.notification.reply_to.email = test_user_reply+{content_id}@localhost
@@ -709,6 +746,7 @@ email.notification.smtp.server = 127.0.0.1
 email.notification.smtp.port = 1025
 email.notification.smtp.user = test_user
 email.notification.smtp.password = just_a_password
+email.notification.smtp.connect_method = unsecure
 website.base_url = http://localhost:6543
 user.reset_password.token_lifetime = 5
 email.notification.enabled_on_invitation = True
@@ -742,6 +780,7 @@ email.notification.smtp.server = 127.0.0.1
 email.notification.smtp.port = 1025
 email.notification.smtp.user = test_user
 email.notification.smtp.password = just_a_password
+email.notification.smtp.connect_method = unsecure
 website.base_url = http://localhost:6543
 user.reset_password.token_lifetime = 5
 auth_types=ldap
@@ -786,6 +825,7 @@ email.notification.smtp.server = 127.0.0.1
 email.notification.smtp.port = 1025
 email.notification.smtp.user = test_user
 email.notification.smtp.password = just_a_password
+email.notification.smtp.connect_method = unsecure
 email.notification.from.email = test_user_from+{user_id}@localhost
 email.notification.from.default_label = Tracim Notifications
 email.notification.reply_to.email = test_user_reply+{content_id}@localhost
@@ -823,6 +863,7 @@ email.notification.smtp.server = 127.0.0.1
 email.notification.smtp.port = 1025
 email.notification.smtp.user = test_user
 email.notification.smtp.password = just_a_password
+email.notification.smtp.connect_method = unsecure
 website.base_url = http://localhost:6543
 user.reset_password.token_lifetime = 5
 email.notification.enabled_on_invitation = False
@@ -860,6 +901,7 @@ email.notification.smtp.server = 127.0.0.1
 email.notification.smtp.port = 1025
 email.notification.smtp.user = test_user
 email.notification.smtp.password = just_a_password
+email.notification.smtp.connect_method = unsecure
 email.required = False
 website.base_url = http://localhost:6543
 user.reset_password.token_lifetime = 5
@@ -897,6 +939,7 @@ email.notification.smtp.server = 127.0.0.1
 email.notification.smtp.port = 1025
 email.notification.smtp.user = test_user
 email.notification.smtp.password = just_a_password
+email.notification.smtp.connect_method = unsecure
 website.base_url = http://localhost:6543
 user.reset_password.token_lifetime = 5
 

--- a/backend/tests_configs.ini
+++ b/backend/tests_configs.ini
@@ -148,7 +148,7 @@ email.notification.smtp.server = 127.0.0.1
 email.notification.smtp.port = 1025
 email.notification.smtp.user = test_user
 email.notification.smtp.password = just_a_password
-email.notification.smtp.connect_method = unsecure
+email.notification.smtp.encryption = no
 
 
 [functional_ldap_and_internal_test]
@@ -193,7 +193,7 @@ email.notification.smtp.server = 127.0.0.1
 email.notification.smtp.port = 1025
 email.notification.smtp.user = test_user
 email.notification.smtp.password = just_a_password
-email.notification.smtp.connect_method = unsecure
+email.notification.smtp.encryption = no
 website.base_url = http://localhost:6543
 
 [mail_test_anonymous]
@@ -225,8 +225,8 @@ email.notification.smtp.server = 127.0.0.1
 email.notification.smtp.port = 1025
 email.notification.smtp.user =
 email.notification.smtp.password =
-email.notification.smtp.anonymous = True
-email.notification.smtp.connect_method = unsecure
+email.notification.smtp.authentication = False
+email.notification.smtp.encryption = no
 website.base_url = http://localhost:6543
 
 [mail_test_async]
@@ -258,7 +258,7 @@ email.notification.smtp.server = 127.0.0.1
 email.notification.smtp.port = 1025
 email.notification.smtp.user = test_user
 email.notification.smtp.password = just_a_password
-email.notification.smtp.connect_method = unsecure
+email.notification.smtp.encryption = no
 website.base_url = http://localhost:6543
 
 [functional_live_test]
@@ -500,7 +500,7 @@ email.notification.smtp.server = 127.0.0.1
 email.notification.smtp.port = 1025
 email.notification.smtp.user = test_user
 email.notification.smtp.password = just_a_password
-email.notification.smtp.connect_method = unsecure
+email.notification.smtp.encryption = no
 email.notification.from.email = test_user_from+{user_id}@localhost
 email.notification.from.default_label = Tracim Notifications
 email.notification.reply_to.email = test_user_reply+{content_id}@localhost
@@ -746,7 +746,7 @@ email.notification.smtp.server = 127.0.0.1
 email.notification.smtp.port = 1025
 email.notification.smtp.user = test_user
 email.notification.smtp.password = just_a_password
-email.notification.smtp.connect_method = unsecure
+email.notification.smtp.encryption = no
 website.base_url = http://localhost:6543
 user.reset_password.token_lifetime = 5
 email.notification.enabled_on_invitation = True
@@ -780,7 +780,7 @@ email.notification.smtp.server = 127.0.0.1
 email.notification.smtp.port = 1025
 email.notification.smtp.user = test_user
 email.notification.smtp.password = just_a_password
-email.notification.smtp.connect_method = unsecure
+email.notification.smtp.encryption = no
 website.base_url = http://localhost:6543
 user.reset_password.token_lifetime = 5
 auth_types=ldap
@@ -825,7 +825,7 @@ email.notification.smtp.server = 127.0.0.1
 email.notification.smtp.port = 1025
 email.notification.smtp.user = test_user
 email.notification.smtp.password = just_a_password
-email.notification.smtp.connect_method = unsecure
+email.notification.smtp.encryption = no
 email.notification.from.email = test_user_from+{user_id}@localhost
 email.notification.from.default_label = Tracim Notifications
 email.notification.reply_to.email = test_user_reply+{content_id}@localhost
@@ -863,7 +863,7 @@ email.notification.smtp.server = 127.0.0.1
 email.notification.smtp.port = 1025
 email.notification.smtp.user = test_user
 email.notification.smtp.password = just_a_password
-email.notification.smtp.connect_method = unsecure
+email.notification.smtp.encryption = no
 website.base_url = http://localhost:6543
 user.reset_password.token_lifetime = 5
 email.notification.enabled_on_invitation = False
@@ -901,7 +901,7 @@ email.notification.smtp.server = 127.0.0.1
 email.notification.smtp.port = 1025
 email.notification.smtp.user = test_user
 email.notification.smtp.password = just_a_password
-email.notification.smtp.connect_method = unsecure
+email.notification.smtp.encryption = no
 email.required = False
 website.base_url = http://localhost:6543
 user.reset_password.token_lifetime = 5
@@ -939,7 +939,7 @@ email.notification.smtp.server = 127.0.0.1
 email.notification.smtp.port = 1025
 email.notification.smtp.user = test_user
 email.notification.smtp.password = just_a_password
-email.notification.smtp.connect_method = unsecure
+email.notification.smtp.encryption = no
 website.base_url = http://localhost:6543
 user.reset_password.token_lifetime = 5
 

--- a/backend/tests_configs.ini
+++ b/backend/tests_configs.ini
@@ -148,7 +148,7 @@ email.notification.smtp.server = 127.0.0.1
 email.notification.smtp.port = 1025
 email.notification.smtp.user = test_user
 email.notification.smtp.password = just_a_password
-email.notification.smtp.encryption = no
+email.notification.smtp.encryption = unsecure
 
 
 [functional_ldap_and_internal_test]
@@ -193,7 +193,7 @@ email.notification.smtp.server = 127.0.0.1
 email.notification.smtp.port = 1025
 email.notification.smtp.user = test_user
 email.notification.smtp.password = just_a_password
-email.notification.smtp.encryption = no
+email.notification.smtp.encryption = unsecure
 website.base_url = http://localhost:6543
 
 [mail_test_anonymous]
@@ -226,7 +226,7 @@ email.notification.smtp.port = 1025
 email.notification.smtp.user =
 email.notification.smtp.password =
 email.notification.smtp.authentication = False
-email.notification.smtp.encryption = no
+email.notification.smtp.encryption = unsecure
 website.base_url = http://localhost:6543
 
 [mail_test_async]
@@ -258,7 +258,7 @@ email.notification.smtp.server = 127.0.0.1
 email.notification.smtp.port = 1025
 email.notification.smtp.user = test_user
 email.notification.smtp.password = just_a_password
-email.notification.smtp.encryption = no
+email.notification.smtp.encryption = unsecure
 website.base_url = http://localhost:6543
 
 [functional_live_test]
@@ -500,7 +500,7 @@ email.notification.smtp.server = 127.0.0.1
 email.notification.smtp.port = 1025
 email.notification.smtp.user = test_user
 email.notification.smtp.password = just_a_password
-email.notification.smtp.encryption = no
+email.notification.smtp.encryption = unsecure
 email.notification.from.email = test_user_from+{user_id}@localhost
 email.notification.from.default_label = Tracim Notifications
 email.notification.reply_to.email = test_user_reply+{content_id}@localhost
@@ -746,7 +746,7 @@ email.notification.smtp.server = 127.0.0.1
 email.notification.smtp.port = 1025
 email.notification.smtp.user = test_user
 email.notification.smtp.password = just_a_password
-email.notification.smtp.encryption = no
+email.notification.smtp.encryption = unsecure
 website.base_url = http://localhost:6543
 user.reset_password.token_lifetime = 5
 email.notification.enabled_on_invitation = True
@@ -780,7 +780,7 @@ email.notification.smtp.server = 127.0.0.1
 email.notification.smtp.port = 1025
 email.notification.smtp.user = test_user
 email.notification.smtp.password = just_a_password
-email.notification.smtp.encryption = no
+email.notification.smtp.encryption = unsecure
 website.base_url = http://localhost:6543
 user.reset_password.token_lifetime = 5
 auth_types=ldap
@@ -825,7 +825,7 @@ email.notification.smtp.server = 127.0.0.1
 email.notification.smtp.port = 1025
 email.notification.smtp.user = test_user
 email.notification.smtp.password = just_a_password
-email.notification.smtp.encryption = no
+email.notification.smtp.encryption = unsecure
 email.notification.from.email = test_user_from+{user_id}@localhost
 email.notification.from.default_label = Tracim Notifications
 email.notification.reply_to.email = test_user_reply+{content_id}@localhost
@@ -863,7 +863,7 @@ email.notification.smtp.server = 127.0.0.1
 email.notification.smtp.port = 1025
 email.notification.smtp.user = test_user
 email.notification.smtp.password = just_a_password
-email.notification.smtp.encryption = no
+email.notification.smtp.encryption = unsecure
 website.base_url = http://localhost:6543
 user.reset_password.token_lifetime = 5
 email.notification.enabled_on_invitation = False
@@ -901,7 +901,7 @@ email.notification.smtp.server = 127.0.0.1
 email.notification.smtp.port = 1025
 email.notification.smtp.user = test_user
 email.notification.smtp.password = just_a_password
-email.notification.smtp.encryption = no
+email.notification.smtp.encryption = unsecure
 email.required = False
 website.base_url = http://localhost:6543
 user.reset_password.token_lifetime = 5
@@ -939,7 +939,7 @@ email.notification.smtp.server = 127.0.0.1
 email.notification.smtp.port = 1025
 email.notification.smtp.user = test_user
 email.notification.smtp.password = just_a_password
-email.notification.smtp.encryption = no
+email.notification.smtp.encryption = unsecure
 website.base_url = http://localhost:6543
 user.reset_password.token_lifetime = 5
 

--- a/backend/tracim_backend/applications/share/lib.py
+++ b/backend/tracim_backend/applications/share/lib.py
@@ -113,8 +113,8 @@ class ShareLib(object):
             config.EMAIL__NOTIFICATION__SMTP__PORT,
             config.EMAIL__NOTIFICATION__SMTP__USER,
             config.EMAIL__NOTIFICATION__SMTP__PASSWORD,
-            config.EMAIL__NOTIFICATION__SMTP__CONNECT_METHOD,
-            config.EMAIL__NOTIFICATION__SMTP__ANONYMOUS,
+            config.EMAIL__NOTIFICATION__SMTP__ENCRYPTION,
+            config.EMAIL__NOTIFICATION__SMTP__AUTHENTICATION,
         )
 
         return ShareEmailManager(config=config, smtp_config=smtp_config, session=session)

--- a/backend/tracim_backend/applications/share/lib.py
+++ b/backend/tracim_backend/applications/share/lib.py
@@ -113,7 +113,8 @@ class ShareLib(object):
             config.EMAIL__NOTIFICATION__SMTP__PORT,
             config.EMAIL__NOTIFICATION__SMTP__USER,
             config.EMAIL__NOTIFICATION__SMTP__PASSWORD,
-            config.EMAIL__NOTIFICATION__SMTP__USE_IMPLICIT_SSL,
+            config.EMAIL__NOTIFICATION__SMTP__CONNECT_METHOD,
+            config.EMAIL__NOTIFICATION__SMTP__ANONYMOUS,
         )
 
         return ShareEmailManager(config=config, smtp_config=smtp_config, session=session)

--- a/backend/tracim_backend/applications/upload_permissions/lib.py
+++ b/backend/tracim_backend/applications/upload_permissions/lib.py
@@ -130,8 +130,8 @@ class UploadPermissionLib(object):
             config.EMAIL__NOTIFICATION__SMTP__PORT,
             config.EMAIL__NOTIFICATION__SMTP__USER,
             config.EMAIL__NOTIFICATION__SMTP__PASSWORD,
-            config.EMAIL__NOTIFICATION__SMTP__CONNECT_METHOD,
-            config.EMAIL__NOTIFICATION__SMTP__ANONYMOUS,
+            config.EMAIL__NOTIFICATION__SMTP__ENCRYPTION,
+            config.EMAIL__NOTIFICATION__SMTP__AUTHENTICATION,
         )
 
         return UploadPermissionEmailManager(config=config, smtp_config=smtp_config, session=session)

--- a/backend/tracim_backend/applications/upload_permissions/lib.py
+++ b/backend/tracim_backend/applications/upload_permissions/lib.py
@@ -130,7 +130,8 @@ class UploadPermissionLib(object):
             config.EMAIL__NOTIFICATION__SMTP__PORT,
             config.EMAIL__NOTIFICATION__SMTP__USER,
             config.EMAIL__NOTIFICATION__SMTP__PASSWORD,
-            config.EMAIL__NOTIFICATION__SMTP__USE_IMPLICIT_SSL,
+            config.EMAIL__NOTIFICATION__SMTP__CONNECT_METHOD,
+            config.EMAIL__NOTIFICATION__SMTP__ANONYMOUS,
         )
 
         return UploadPermissionEmailManager(config=config, smtp_config=smtp_config, session=session)

--- a/backend/tracim_backend/command/devtools.py
+++ b/backend/tracim_backend/command/devtools.py
@@ -224,8 +224,8 @@ class SMTPMailCheckerCommand(AppContextCommand):
             self._app_config.EMAIL__NOTIFICATION__SMTP__SERVER,
             self._app_config.EMAIL__NOTIFICATION__SMTP__PORT,
             self._app_config.EMAIL__NOTIFICATION__SMTP__USER,
-            self._app_config.EMAIL__NOTIFICATION__SMTP__PASSWORD,
-            self._app_config.EMAIL__NOTIFICATION__SMTP__USE_IMPLICIT_SSL,
+            self._app_config.EMAIL__NOTIFICATION__SMTP__CONNECT_METHOD,
+            self._app_config.EMAIL__NOTIFICATION__SMTP__ANONYMOUS,
         )
         sender = EmailSender(self._app_config, smtp_config, True)
         html = """\

--- a/backend/tracim_backend/command/devtools.py
+++ b/backend/tracim_backend/command/devtools.py
@@ -224,6 +224,7 @@ class SMTPMailCheckerCommand(AppContextCommand):
             self._app_config.EMAIL__NOTIFICATION__SMTP__SERVER,
             self._app_config.EMAIL__NOTIFICATION__SMTP__PORT,
             self._app_config.EMAIL__NOTIFICATION__SMTP__USER,
+            self._app_config.EMAIL__NOTIFICATION__SMTP__PASSWORD,
             self._app_config.EMAIL__NOTIFICATION__SMTP__CONNECT_METHOD,
             self._app_config.EMAIL__NOTIFICATION__SMTP__ANONYMOUS,
         )

--- a/backend/tracim_backend/command/devtools.py
+++ b/backend/tracim_backend/command/devtools.py
@@ -225,8 +225,8 @@ class SMTPMailCheckerCommand(AppContextCommand):
             self._app_config.EMAIL__NOTIFICATION__SMTP__PORT,
             self._app_config.EMAIL__NOTIFICATION__SMTP__USER,
             self._app_config.EMAIL__NOTIFICATION__SMTP__PASSWORD,
-            self._app_config.EMAIL__NOTIFICATION__SMTP__CONNECT_METHOD,
-            self._app_config.EMAIL__NOTIFICATION__SMTP__ANONYMOUS,
+            self._app_config.EMAIL__NOTIFICATION__SMTP__ENCRYPTION,
+            self._app_config.EMAIL__NOTIFICATION__SMTP__AUTHENTICATION,
         )
         sender = EmailSender(self._app_config, smtp_config, True)
         html = """\

--- a/backend/tracim_backend/config.py
+++ b/backend/tracim_backend/config.py
@@ -1217,16 +1217,6 @@ class CFG(object):
                 self.EMAIL__NOTIFICATION__SMTP__PORT,
                 when_str="when email notification is activated",
             )
-            self.check_mandatory_param(
-                "EMAIL__NOTIFICATION__SMTP__USER",
-                self.EMAIL__NOTIFICATION__SMTP__USER,
-                when_str="when email notification is activated",
-            )
-            self.check_mandatory_param(
-                "EMAIL__NOTIFICATION__SMTP__PASSWORD",
-                self.EMAIL__NOTIFICATION__SMTP__PASSWORD,
-                when_str="when email notification is activated",
-            )
             # INFO - G.M - 2019-12-10 - check value provided for headers
             self.check_mandatory_param(
                 "EMAIL__NOTIFICATION__FROM__EMAIL",

--- a/backend/tracim_backend/config.py
+++ b/backend/tracim_backend/config.py
@@ -19,6 +19,7 @@ from tracim_backend.exceptions import NotReadableFile
 from tracim_backend.exceptions import NotWritableDirectory
 from tracim_backend.extensions import app_list
 from tracim_backend.lib.core.application import ApplicationApi
+from tracim_backend.lib.mail_notifier.utils import SmtpConnectMethod
 from tracim_backend.lib.translate.providers import TRANSLATION_SERVICE_CLASSES
 from tracim_backend.lib.translate.providers import TranslationProvider
 from tracim_backend.lib.utils.app import TracimApplication
@@ -705,8 +706,22 @@ class CFG(object):
         self.EMAIL__NOTIFICATION__SMTP__PASSWORD = self.get_raw_config(
             "email.notification.smtp.password", secret=True
         )
+        self.EMAIL__NOTIFICATION__SMTP__ANONYMOUS = asbool(
+            self.get_raw_config("email.notification.smtp.anonymous", "False")
+        )
         self.EMAIL__NOTIFICATION__SMTP__USE_IMPLICIT_SSL = asbool(
-            self.get_raw_config("email.notification.smtp.use_implicit_ssl", "false")
+            self.get_raw_config(
+                "email.notification.smtp.use_implicit_ssl",
+                "false",
+                deprecated=True,
+                deprecated_extended_information="Use EMAIL__NOTIFICATION__SMTP__CONNECT_METHOD parameter instead.",
+            )
+        )
+        default_smtp_connect_method = "default"
+        if self.EMAIL__NOTIFICATION__SMTP__USE_IMPLICIT_SSL:
+            default_smtp_connect_method = "smtps"
+        self.EMAIL__NOTIFICATION__SMTP__CONNECT_METHOD = self.get_raw_config(
+            "email.notification.smtp.connect_method", default_smtp_connect_method
         )
 
         self.EMAIL__REPLY__ACTIVATED = asbool(self.get_raw_config("email.reply.activated", "False"))
@@ -1217,16 +1232,35 @@ class CFG(object):
                 self.EMAIL__NOTIFICATION__SMTP__PORT,
                 when_str="when email notification is activated",
             )
-            self.check_mandatory_param(
-                "EMAIL__NOTIFICATION__SMTP__USER",
-                self.EMAIL__NOTIFICATION__SMTP__USER,
-                when_str="when email notification is activated",
-            )
-            self.check_mandatory_param(
-                "EMAIL__NOTIFICATION__SMTP__PASSWORD",
-                self.EMAIL__NOTIFICATION__SMTP__PASSWORD,
-                when_str="when email notification is activated",
-            )
+            if not self.EMAIL__NOTIFICATION__SMTP__ANONYMOUS:
+                self.check_mandatory_param(
+                    "EMAIL__NOTIFICATION__SMTP__USER",
+                    self.EMAIL__NOTIFICATION__SMTP__USER,
+                    when_str="when email notification is activated and smtp config not set as anonymous",
+                )
+                self.check_mandatory_param(
+                    "EMAIL__NOTIFICATION__SMTP__PASSWORD",
+                    self.EMAIL__NOTIFICATION__SMTP__PASSWORD,
+                    when_str="when email notification is activated and smtp config not set as anonymous",
+                )
+
+            if (
+                self.EMAIL__NOTIFICATION__SMTP__CONNECT_METHOD
+                not in SmtpConnectMethod.get_all_values()
+            ):
+                smtp_connect_method_str_list = ", ".join(
+                    [
+                        '"{}"'.format(smtp_connect_method_name)
+                        for smtp_connect_method_name in SmtpConnectMethod.get_all_values()
+                    ]
+                )
+                raise ConfigurationError(
+                    'ERROR email.notification.smtp_connect_method given "{}" is invalid,'
+                    "valids values are {}.".format(
+                        self.EMAIL__NOTIFICATION__SMTP__CONNECT_METHOD, smtp_connect_method_str_list
+                    )
+                )
+
             # INFO - G.M - 2019-12-10 - check value provided for headers
             self.check_mandatory_param(
                 "EMAIL__NOTIFICATION__FROM__EMAIL",

--- a/backend/tracim_backend/config.py
+++ b/backend/tracim_backend/config.py
@@ -19,7 +19,7 @@ from tracim_backend.exceptions import NotReadableFile
 from tracim_backend.exceptions import NotWritableDirectory
 from tracim_backend.extensions import app_list
 from tracim_backend.lib.core.application import ApplicationApi
-from tracim_backend.lib.mail_notifier.utils import SmtpConnectMethod
+from tracim_backend.lib.mail_notifier.utils import SmtpEncryption
 from tracim_backend.lib.translate.providers import TRANSLATION_SERVICE_CLASSES
 from tracim_backend.lib.translate.providers import TranslationProvider
 from tracim_backend.lib.utils.app import TracimApplication
@@ -706,8 +706,8 @@ class CFG(object):
         self.EMAIL__NOTIFICATION__SMTP__PASSWORD = self.get_raw_config(
             "email.notification.smtp.password", secret=True
         )
-        self.EMAIL__NOTIFICATION__SMTP__ANONYMOUS = asbool(
-            self.get_raw_config("email.notification.smtp.anonymous", "False")
+        self.EMAIL__NOTIFICATION__SMTP__AUTHENTICATION = asbool(
+            self.get_raw_config("email.notification.smtp.authentication", "True")
         )
         self.EMAIL__NOTIFICATION__SMTP__USE_IMPLICIT_SSL = asbool(
             self.get_raw_config(
@@ -717,11 +717,11 @@ class CFG(object):
                 deprecated_extended_information="Use EMAIL__NOTIFICATION__SMTP__CONNECT_METHOD parameter instead.",
             )
         )
-        default_smtp_connect_method = "default"
+        default_smtp_encryption = "default"
         if self.EMAIL__NOTIFICATION__SMTP__USE_IMPLICIT_SSL:
-            default_smtp_connect_method = "smtps"
-        self.EMAIL__NOTIFICATION__SMTP__CONNECT_METHOD = self.get_raw_config(
-            "email.notification.smtp.connect_method", default_smtp_connect_method
+            default_smtp_encryption = "smtps"
+        self.EMAIL__NOTIFICATION__SMTP__ENCRYPTION = self.get_raw_config(
+            "email.notification.smtp.encryption", default_smtp_encryption
         )
 
         self.EMAIL__REPLY__ACTIVATED = asbool(self.get_raw_config("email.reply.activated", "False"))
@@ -1232,7 +1232,7 @@ class CFG(object):
                 self.EMAIL__NOTIFICATION__SMTP__PORT,
                 when_str="when email notification is activated",
             )
-            if not self.EMAIL__NOTIFICATION__SMTP__ANONYMOUS:
+            if self.EMAIL__NOTIFICATION__SMTP__AUTHENTICATION:
                 self.check_mandatory_param(
                     "EMAIL__NOTIFICATION__SMTP__USER",
                     self.EMAIL__NOTIFICATION__SMTP__USER,
@@ -1244,20 +1244,17 @@ class CFG(object):
                     when_str="when email notification is activated and smtp config not set as anonymous",
                 )
 
-            if (
-                self.EMAIL__NOTIFICATION__SMTP__CONNECT_METHOD
-                not in SmtpConnectMethod.get_all_values()
-            ):
-                smtp_connect_method_str_list = ", ".join(
+            if self.EMAIL__NOTIFICATION__SMTP__ENCRYPTION not in SmtpEncryption.get_all_values():
+                smtp_encryption_str_list = ", ".join(
                     [
                         '"{}"'.format(smtp_connect_method_name)
-                        for smtp_connect_method_name in SmtpConnectMethod.get_all_values()
+                        for smtp_connect_method_name in SmtpEncryption.get_all_values()
                     ]
                 )
                 raise ConfigurationError(
-                    'ERROR email.notification.smtp_connect_method given "{}" is invalid,'
+                    'ERROR email.notification.smtp.encryption given "{}" is invalid,'
                     "valids values are {}.".format(
-                        self.EMAIL__NOTIFICATION__SMTP__CONNECT_METHOD, smtp_connect_method_str_list
+                        self.EMAIL__NOTIFICATION__SMTP__ENCRYPTION, smtp_encryption_str_list
                     )
                 )
 

--- a/backend/tracim_backend/config.py
+++ b/backend/tracim_backend/config.py
@@ -1217,6 +1217,16 @@ class CFG(object):
                 self.EMAIL__NOTIFICATION__SMTP__PORT,
                 when_str="when email notification is activated",
             )
+            self.check_mandatory_param(
+                "EMAIL__NOTIFICATION__SMTP__USER",
+                self.EMAIL__NOTIFICATION__SMTP__USER,
+                when_str="when email notification is activated",
+            )
+            self.check_mandatory_param(
+                "EMAIL__NOTIFICATION__SMTP__PASSWORD",
+                self.EMAIL__NOTIFICATION__SMTP__PASSWORD,
+                when_str="when email notification is activated",
+            )
             # INFO - G.M - 2019-12-10 - check value provided for headers
             self.check_mandatory_param(
                 "EMAIL__NOTIFICATION__FROM__EMAIL",

--- a/backend/tracim_backend/lib/mail_notifier/notifier.py
+++ b/backend/tracim_backend/lib/mail_notifier/notifier.py
@@ -51,7 +51,8 @@ class EmailNotifier(INotifier):
             self.config.EMAIL__NOTIFICATION__SMTP__PORT,
             self.config.EMAIL__NOTIFICATION__SMTP__USER,
             self.config.EMAIL__NOTIFICATION__SMTP__PASSWORD,
-            self.config.EMAIL__NOTIFICATION__SMTP__USE_IMPLICIT_SSL,
+            self.config.EMAIL__NOTIFICATION__SMTP__CONNECT_METHOD,
+            self.config.EMAIL__NOTIFICATION__SMTP__ANONYMOUS,
         )
 
     def notify_content_update(self, content: Content):
@@ -543,7 +544,8 @@ def get_email_manager(config: CFG, session: Session):
         config.EMAIL__NOTIFICATION__SMTP__PORT,
         config.EMAIL__NOTIFICATION__SMTP__USER,
         config.EMAIL__NOTIFICATION__SMTP__PASSWORD,
-        config.EMAIL__NOTIFICATION__SMTP__USE_IMPLICIT_SSL,
+        config.EMAIL__NOTIFICATION__SMTP__CONNECT_METHOD,
+        config.EMAIL__NOTIFICATION__SMTP__ANONYMOUS,
     )
 
     return EmailManager(config=config, smtp_config=smtp_config, session=session)

--- a/backend/tracim_backend/lib/mail_notifier/notifier.py
+++ b/backend/tracim_backend/lib/mail_notifier/notifier.py
@@ -51,8 +51,8 @@ class EmailNotifier(INotifier):
             self.config.EMAIL__NOTIFICATION__SMTP__PORT,
             self.config.EMAIL__NOTIFICATION__SMTP__USER,
             self.config.EMAIL__NOTIFICATION__SMTP__PASSWORD,
-            self.config.EMAIL__NOTIFICATION__SMTP__CONNECT_METHOD,
-            self.config.EMAIL__NOTIFICATION__SMTP__ANONYMOUS,
+            self.config.EMAIL__NOTIFICATION__SMTP__ENCRYPTION,
+            self.config.EMAIL__NOTIFICATION__SMTP__AUTHENTICATION,
         )
 
     def notify_content_update(self, content: Content):
@@ -544,8 +544,8 @@ def get_email_manager(config: CFG, session: Session):
         config.EMAIL__NOTIFICATION__SMTP__PORT,
         config.EMAIL__NOTIFICATION__SMTP__USER,
         config.EMAIL__NOTIFICATION__SMTP__PASSWORD,
-        config.EMAIL__NOTIFICATION__SMTP__CONNECT_METHOD,
-        config.EMAIL__NOTIFICATION__SMTP__ANONYMOUS,
+        config.EMAIL__NOTIFICATION__SMTP__ENCRYPTION,
+        config.EMAIL__NOTIFICATION__SMTP__AUTHENTICATION,
     )
 
     return EmailManager(config=config, smtp_config=smtp_config, session=session)

--- a/backend/tracim_backend/lib/mail_notifier/sender.py
+++ b/backend/tracim_backend/lib/mail_notifier/sender.py
@@ -5,7 +5,7 @@ import typing
 
 from tracim_backend.config import CFG
 from tracim_backend.lib.mail_notifier.utils import SmtpConfiguration
-from tracim_backend.lib.mail_notifier.utils import SmtpConnectMethod
+from tracim_backend.lib.mail_notifier.utils import SmtpEncryption
 from tracim_backend.lib.rq import RqQueueName
 from tracim_backend.lib.rq import get_redis_connection
 from tracim_backend.lib.rq import get_rq_queue
@@ -61,7 +61,7 @@ class EmailSender(object):
         if not self._smtp_connection:
             log = "Connecting to SMTP server {}"
             logger.info(self, log.format(self._smtp_config.server))
-            if self._smtp_config.connect_method == SmtpConnectMethod.SMTPS:
+            if self._smtp_config.encryption == SmtpEncryption.SMTPS:
                 self._smtp_connection = smtplib.SMTP_SSL(
                     self._smtp_config.server, self._smtp_config.port
                 )
@@ -71,7 +71,7 @@ class EmailSender(object):
                 )
             self._smtp_connection.ehlo()
 
-            if self._smtp_config.connect_method == SmtpConnectMethod.DEFAULT:
+            if self._smtp_config.encryption == SmtpEncryption.DEFAULT:
                 try:
                     starttls_result = self._smtp_connection.starttls()
 
@@ -89,7 +89,7 @@ class EmailSender(object):
                     log = "Unexpected exception during SMTP start TLS process"
                     logger.exception(self, log)
 
-            if not self._smtp_config.anonymous:
+            if self._smtp_config.authentication:
                 try:
                     login_res = self._smtp_connection.login(
                         self._smtp_config.login, self._smtp_config.password

--- a/backend/tracim_backend/lib/mail_notifier/sender.py
+++ b/backend/tracim_backend/lib/mail_notifier/sender.py
@@ -5,6 +5,7 @@ import typing
 
 from tracim_backend.config import CFG
 from tracim_backend.lib.mail_notifier.utils import SmtpConfiguration
+from tracim_backend.lib.mail_notifier.utils import SmtpConnectMethod
 from tracim_backend.lib.rq import RqQueueName
 from tracim_backend.lib.rq import get_redis_connection
 from tracim_backend.lib.rq import get_rq_queue
@@ -60,7 +61,7 @@ class EmailSender(object):
         if not self._smtp_connection:
             log = "Connecting to SMTP server {}"
             logger.info(self, log.format(self._smtp_config.server))
-            if self._smtp_config.use_implicit_ssl:
+            if self._smtp_config.connect_method == SmtpConnectMethod.SMTPS:
                 self._smtp_connection = smtplib.SMTP_SSL(
                     self._smtp_config.server, self._smtp_config.port
                 )
@@ -70,9 +71,7 @@ class EmailSender(object):
                 )
             self._smtp_connection.ehlo()
 
-            # TODO - G.M - 2020-04-02 - Starttls usage should be explicit in configuration, see
-            # https://github.com/tracim/tracim/issues/2815
-            if self._smtp_config.login and not self._smtp_config.use_implicit_ssl:
+            if self._smtp_config.connect_method == SmtpConnectMethod.DEFAULT:
                 try:
                     starttls_result = self._smtp_connection.starttls()
 
@@ -90,7 +89,7 @@ class EmailSender(object):
                     log = "Unexpected exception during SMTP start TLS process"
                     logger.exception(self, log)
 
-            if self._smtp_config.login:
+            if not self._smtp_config.anonymous:
                 try:
                     login_res = self._smtp_connection.login(
                         self._smtp_config.login, self._smtp_config.password

--- a/backend/tracim_backend/lib/mail_notifier/utils.py
+++ b/backend/tracim_backend/lib/mail_notifier/utils.py
@@ -12,14 +12,14 @@ import html2text
 from tracim_backend.lib.utils.sanitizer import HtmlSanitizer
 
 
-class SmtpConnectMethod(str, enum.Enum):
+class SmtpEncryption(str, enum.Enum):
     DEFAULT = "default"  # use starttls, fallback to unencrypted
-    UNSECURE = "unsecure"  # unencrypted
+    NO = "no"  # unencrypted
     SMTPS = "smtps"  # use direct encryption
 
     @classmethod
     def get_all_values(cls) -> typing.List[str]:
-        return [cm.value for cm in SmtpConnectMethod]
+        return [cm.value for cm in SmtpEncryption]
 
 
 class SmtpConfiguration(object):
@@ -31,15 +31,15 @@ class SmtpConfiguration(object):
         port: int,
         login: str,
         password: str,
-        connect_method: SmtpConnectMethod,
-        anonymous: bool,
+        encryption: SmtpEncryption,
+        authentication: bool,
     ):
         self.server = server
         self.port = port
         self.login = login
         self.password = password
-        self.connect_method = connect_method
-        self.anonymous = anonymous
+        self.encryption = encryption
+        self.authentication = authentication
 
 
 class EST(object):

--- a/backend/tracim_backend/lib/mail_notifier/utils.py
+++ b/backend/tracim_backend/lib/mail_notifier/utils.py
@@ -14,7 +14,7 @@ from tracim_backend.lib.utils.sanitizer import HtmlSanitizer
 
 class SmtpEncryption(str, enum.Enum):
     DEFAULT = "default"  # use starttls, fallback to unencrypted
-    NO = "no"  # unencrypted
+    UNSECURE = "unsecure"  # unencrypted
     SMTPS = "smtps"  # use direct encryption
 
     @classmethod

--- a/backend/tracim_backend/lib/mail_notifier/utils.py
+++ b/backend/tracim_backend/lib/mail_notifier/utils.py
@@ -4,6 +4,7 @@ from email.utils import formataddr
 from email.utils import formatdate
 from email.utils import make_msgid
 from email.utils import parseaddr
+import enum
 import typing
 
 import html2text
@@ -11,15 +12,34 @@ import html2text
 from tracim_backend.lib.utils.sanitizer import HtmlSanitizer
 
 
+class SmtpConnectMethod(str, enum.Enum):
+    DEFAULT = "default"  # use starttls, fallback to unencrypted
+    UNSECURE = "unsecure"  # unencrypted
+    SMTPS = "smtps"  # use direct encryption
+
+    @classmethod
+    def get_all_values(cls) -> typing.List[str]:
+        return [cm.value for cm in SmtpConnectMethod]
+
+
 class SmtpConfiguration(object):
     """Container class for SMTP configuration used in Tracim."""
 
-    def __init__(self, server: str, port: int, login: str, password: str, use_implicit_ssl: bool):
+    def __init__(
+        self,
+        server: str,
+        port: int,
+        login: str,
+        password: str,
+        connect_method: SmtpConnectMethod,
+        anonymous: bool,
+    ):
         self.server = server
         self.port = port
         self.login = login
         self.password = password
-        self.use_implicit_ssl = use_implicit_ssl
+        self.connect_method = connect_method
+        self.anonymous = anonymous
 
 
 class EST(object):

--- a/backend/tracim_backend/tests/functional/test_mail_notification.py
+++ b/backend/tracim_backend/tests/functional/test_mail_notification.py
@@ -34,8 +34,8 @@ class TestEmailSender(object):
             app_config.EMAIL__NOTIFICATION__SMTP__PORT,
             app_config.EMAIL__NOTIFICATION__SMTP__USER,
             app_config.EMAIL__NOTIFICATION__SMTP__PASSWORD,
-            app_config.EMAIL__NOTIFICATION__SMTP__CONNECT_METHOD,
-            app_config.EMAIL__NOTIFICATION__SMTP__ANONYMOUS,
+            app_config.EMAIL__NOTIFICATION__SMTP__ENCRYPTION,
+            app_config.EMAIL__NOTIFICATION__SMTP__AUTHENTICATION,
         )
         sender = EmailSender(app_config, smtp_config, True)
         sender.connect()
@@ -47,8 +47,8 @@ class TestEmailSender(object):
             app_config.EMAIL__NOTIFICATION__SMTP__PORT,
             app_config.EMAIL__NOTIFICATION__SMTP__USER,
             app_config.EMAIL__NOTIFICATION__SMTP__PASSWORD,
-            app_config.EMAIL__NOTIFICATION__SMTP__CONNECT_METHOD,
-            app_config.EMAIL__NOTIFICATION__SMTP__ANONYMOUS,
+            app_config.EMAIL__NOTIFICATION__SMTP__ENCRYPTION,
+            app_config.EMAIL__NOTIFICATION__SMTP__AUTHENTICATION,
         )
         sender = EmailSender(app_config, smtp_config, True)
 
@@ -93,8 +93,8 @@ class TestEmailSender(object):
             app_config.EMAIL__NOTIFICATION__SMTP__PORT,
             app_config.EMAIL__NOTIFICATION__SMTP__USER,
             app_config.EMAIL__NOTIFICATION__SMTP__PASSWORD,
-            app_config.EMAIL__NOTIFICATION__SMTP__CONNECT_METHOD,
-            app_config.EMAIL__NOTIFICATION__SMTP__ANONYMOUS,
+            app_config.EMAIL__NOTIFICATION__SMTP__ENCRYPTION,
+            app_config.EMAIL__NOTIFICATION__SMTP__AUTHENTICATION,
         )
         sender = EmailSender(app_config, smtp_config, True)
         html = """\

--- a/backend/tracim_backend/tests/functional/test_mail_notification.py
+++ b/backend/tracim_backend/tests/functional/test_mail_notification.py
@@ -19,7 +19,14 @@ from tracim_backend.lib.rq import get_rq_queue
 from tracim_backend.tests.fixtures import *  # noqa: F403,F40
 
 
-@pytest.mark.parametrize("config_section", [{"name": "mail_test"}], indirect=True)
+@pytest.mark.parametrize(
+    "config_section",
+    [
+        {"name": "mail_test"},  # unencrypted, authenticated
+        {"name": "mail_test_anonymous"},  # unencrypted, anonymous
+    ],
+    indirect=True,
+)
 class TestEmailSender(object):
     def test__func__connect_disconnect__ok__nominal_case(self, app_config, mailhog):
         smtp_config = SmtpConfiguration(
@@ -27,7 +34,8 @@ class TestEmailSender(object):
             app_config.EMAIL__NOTIFICATION__SMTP__PORT,
             app_config.EMAIL__NOTIFICATION__SMTP__USER,
             app_config.EMAIL__NOTIFICATION__SMTP__PASSWORD,
-            app_config.EMAIL__NOTIFICATION__SMTP__USE_IMPLICIT_SSL,
+            app_config.EMAIL__NOTIFICATION__SMTP__CONNECT_METHOD,
+            app_config.EMAIL__NOTIFICATION__SMTP__ANONYMOUS,
         )
         sender = EmailSender(app_config, smtp_config, True)
         sender.connect()
@@ -39,7 +47,8 @@ class TestEmailSender(object):
             app_config.EMAIL__NOTIFICATION__SMTP__PORT,
             app_config.EMAIL__NOTIFICATION__SMTP__USER,
             app_config.EMAIL__NOTIFICATION__SMTP__PASSWORD,
-            app_config.EMAIL__NOTIFICATION__SMTP__USE_IMPLICIT_SSL,
+            app_config.EMAIL__NOTIFICATION__SMTP__CONNECT_METHOD,
+            app_config.EMAIL__NOTIFICATION__SMTP__ANONYMOUS,
         )
         sender = EmailSender(app_config, smtp_config, True)
 
@@ -84,7 +93,8 @@ class TestEmailSender(object):
             app_config.EMAIL__NOTIFICATION__SMTP__PORT,
             app_config.EMAIL__NOTIFICATION__SMTP__USER,
             app_config.EMAIL__NOTIFICATION__SMTP__PASSWORD,
-            app_config.EMAIL__NOTIFICATION__SMTP__USE_IMPLICIT_SSL,
+            app_config.EMAIL__NOTIFICATION__SMTP__CONNECT_METHOD,
+            app_config.EMAIL__NOTIFICATION__SMTP__ANONYMOUS,
         )
         sender = EmailSender(app_config, smtp_config, True)
         html = """\


### PR DESCRIPTION
YunoHost include a postfix smtp server. And as almost servers, it allows to send mail to local users anonymously

Tested on YunoHost, when creating a user in tracim, YunoHost user receive the invitation mail

Fixe #2954

## Checkpoints

<!-- These points must be checked before merging. Please don't edit them out. -->

**For developers**

- [x] If relevant, manual tests have been done to ensure the stability of the whole application and that the involved feature works
- [x] The original issue is up to date w.r.t the latest discussions and contains a short summary of the implemented solution
- [x] Automated tests covering the feature or the fix, have been written, deemed irrelevant (give the reason), or an issue has been created to implement the test (give the link)
- [x] Make sure that:
  - if there are modifications in the Tracim configuration files (eg. `development.ini`), they are documented in `backend/doc/setting.md`
  - any migration process required for existing instances is documented
  - relevant people for these changes are notified
- [x] Original authors of the features included in a multi-feature branch (maintenance fixes -> develop, security fixes -> develop, …) should be part of the reviewers, especially if you encountered merge conflicts.

**For code reviewers**

- [x] The code is clear enough
- [x] If there are FIXMEs in the code, related issues are mentioned in the FIXME
- [x] If there are TODOs, NOTEs or HACKs in code, the date and the developer initials are present

**For testers**

- [ ] Manual, quality tests have been done
