### PR TITLE
feat(backend): permit use update folder api without giving sub_conten…

### DIFF
--- a/backend/tracim_backend/lib/core/content.py
+++ b/backend/tracim_backend/lib/core/content.py
@@ -1586,7 +1586,7 @@ class ContentApi(object):
     def update_container_content(
         self,
         item: Content,
-        allowed_content_type_slug_list: typing.List[str],
+        allowed_content_type_slug_list: typing.Optional[typing.List[str]],
         new_label: str,
         new_description: typing.Optional[str] = None,
         new_raw_content: typing.Optional[str] = None,
@@ -1602,11 +1602,13 @@ class ContentApi(object):
          of content.
         :return:
         """
-        try:
-            item = self.set_allowed_content(item, allowed_content_type_slug_list)
-            content_has_changed = True
-        except SameValueError:
-            content_has_changed = False
+        content_has_changed = False
+        if allowed_content_type_slug_list is not None:
+            try:
+                item = self.set_allowed_content(item, allowed_content_type_slug_list)
+                content_has_changed = True
+            except SameValueError:
+                pass
         item = self.update_content(
             item,
             new_label,

--- a/backend/tracim_backend/tests/functional/test_contents.py
+++ b/backend/tracim_backend/tests/functional/test_contents.py
@@ -387,6 +387,43 @@ class TestFolder(object):
             k: v for k, v in workspace.items() if k != "description"
         }
 
+    def test_api__update_folder__ok_200__no_allowed_content_given(
+        self,
+        workspace_api_factory,
+        content_api_factory,
+        web_testapp,
+        content_type_list,
+        event_helper,
+    ) -> None:
+        """
+        Update(put) one content without giving sub_content_types parameter
+        """
+
+        workspace_api = workspace_api_factory.get()
+        content_api = content_api_factory.get()
+        test_workspace = workspace_api.create_workspace(label="test", save_now=True)
+        folder = content_api.create(
+            label="test_folder",
+            content_type_slug=content_type_list.Folder.slug,
+            workspace=test_workspace,
+            do_save=True,
+            do_notify=False,
+        )
+        transaction.commit()
+        web_testapp.authorization = ("Basic", ("admin@admin.admin", "admin@admin.admin"))
+        params = {
+            "label": "My New label",
+        }
+        headers = {"X-Tracim-ClientToken": "justaclienttoken"}
+        web_testapp.put_json(
+            "/api/workspaces/{workspace_id}/folders/{content_id}".format(
+                workspace_id=test_workspace.workspace_id, content_id=folder.content_id
+            ),
+            params=params,
+            status=200,
+            headers=headers,
+        )
+
     def test_api__update_folder__err_400__not_modified(
         self, workspace_api_factory, content_api_factory, web_testapp, content_type_list
     ) -> None:

--- a/backend/tracim_backend/views/core_api/schemas.py
+++ b/backend/tracim_backend/views/core_api/schemas.py
@@ -2006,9 +2006,7 @@ class ContentModifySchema(ContentModifyAbstractSchema):
 class FolderContentModifySchema(ContentModifyAbstractSchema):
     sub_content_types = marshmallow.fields.List(
         StrippedString(example="html-document", validate=all_content_types_validator),
-        description="list of content types allowed as sub contents. "
-        "This field is required for folder contents, "
-        "set it to empty list in other cases",
+        description="list of content types allowed as sub contents.",
         required=False,
     )
 


### PR DESCRIPTION
The `PUT /api/workspaces/{workspace_id}/folders/{content_id}` crash if `sub_content_types` not given. This PR avoid crash in this case.

## Checkpoints

<!-- These points must be checked before merging. Please don't edit them out. -->

**For developers**

- [x] If relevant, manual tests have been done to ensure the stability of the whole application and that the involved feature works
~~- [ ] The original issue is up to date w.r.t the latest discussions and contains a short summary of the implemented solution~~ no related issue
- [x] Automated tests covering the feature or the fix, have been written, deemed irrelevant (give the reason), or an issue has been created to implement the test (give the link)
- [x] Make sure that:
  - if there are modifications in the Tracim configuration files (eg. `development.ini`), they are documented in `backend/doc/setting.md`
  - any migration process required for existing instances is documented
  - relevant people for these changes are notified
~~- [ ] Original authors of the features included in a multi-feature branch (maintenance fixes -> develop, security fixes -> develop, …) should be part of the reviewers, especially if you encountered merge conflicts.~~ not relevant

**For code reviewers**

- [x] The code is clear enough
- [x] If there are FIXMEs in the code, related issues are mentioned in the FIXME
- [x] If there are TODOs, NOTEs or HACKs in code, the date and the developer initials are present

**For testers**

- [x] Manual, quality tests have been done
