### PR TITLE
fix(frontend, backend): Mark notification group as read

### DIFF
--- a/backend/tracim_backend/views/core_api/schemas.py
+++ b/backend/tracim_backend/views/core_api/schemas.py
@@ -704,6 +704,15 @@ class UserIdPathSchema(marshmallow.Schema):
     )
 
 
+class EventIdListSchema(marshmallow.Schema):
+    event_id_list = marshmallow.fields.List(
+        marshmallow.fields.Int(
+            example=3, description="id of a valid event", validate=strictly_positive_int_validator,
+        ),
+        required=False,
+    )
+
+
 class EventIdPathSchema(marshmallow.Schema):
     event_id = marshmallow.fields.Int(
         example=5,

--- a/frontend/src/action-creator.async.js
+++ b/frontend/src/action-creator.async.js
@@ -946,6 +946,35 @@ export const getNotificationList = (
   return fetchGetNotificationWall
 }
 
+/**
+ * Put a list of notifications as read
+ * @param {String} userId
+ * @param {int[]} notificationIdList
+ * @returns
+ */
+export const putNotificationListAsRead = (userId, notificationIdList) => dispatch => {
+  return fetchWrapper({
+    url: `${FETCH_CONFIG.apiUrl}/users/${userId}/messages/read`,
+    param: {
+      credentials: 'include',
+      headers: FETCH_CONFIG.headers,
+      method: 'PUT',
+      body: JSON.stringify({
+        event_id_list: notificationIdList
+      })
+    },
+    actionName: NOTIFICATION_LIST,
+    dispatch
+  })
+}
+
+/**
+ * @deprecated
+ * Put a notification as read
+ * @param {String} userId user that read the notification
+ * @param {String} eventId id of the notification to read
+ * @returns
+ */
 export const putNotificationAsRead = (userId, eventId) => dispatch => {
   return fetchWrapper({
     url: `${FETCH_CONFIG.apiUrl}/users/${userId}/messages/${eventId}/read`,

--- a/frontend/src/action-creator.sync.js
+++ b/frontend/src/action-creator.sync.js
@@ -197,16 +197,18 @@ export const APPLIED_FILTER = (searchType) => `AppliedFilter_${searchType}`
 export const setAppliedFilter = (key, value, searchType) => ({ type: `${SET}/${APPLIED_FILTER(searchType)}`, key, value })
 export const resetAppliedFilter = (searchType) => ({ type: `${RESET}/${APPLIED_FILTER(searchType)}` })
 
+export const EVERY_NOTIFICATIONS = 'EveryNotifications'
 export const NEXT_PAGE = 'NextPage'
-export const NOTIFICATION_LIST = 'NotificationList'
 export const NOTIFICATION = 'Notification'
+export const NOTIFICATION_LIST = 'NotificationList'
 export const UNREAD_MENTION_COUNT = 'UnreadMentionCount'
 export const UNREAD_NOTIFICATION_COUNT = 'UnreadNotificationCount'
 export const appendNotificationList = (notificationList, spaceList) => ({ type: `${APPEND}/${NOTIFICATION_LIST}`, notificationList, spaceList })
 export const addNotification = (notification, spaceList) => ({ type: `${ADD}/${NOTIFICATION}`, notification, spaceList })
 export const updateNotification = (notificationId, notificationList) => ({ type: `${UPDATE}/${NOTIFICATION}`, notificationId, notificationList })
 export const readNotification = notificationId => ({ type: `${READ}/${NOTIFICATION}`, notificationId })
-export const readNotificationList = () => ({ type: `${READ}/${NOTIFICATION_LIST}` })
+export const readNotificationList = notificationIdList => ({ type: `${READ}/${NOTIFICATION_LIST}`, notificationIdList })
+export const readEveryNotifications = () => ({ type: `${READ}/${EVERY_NOTIFICATIONS}` })
 export const readContentNotification = contentId => ({ type: `${READ}/${CONTENT}/${NOTIFICATION}`, contentId })
 export const setNextPage = (hasNextPage, nextPageToken) => ({ type: `${SET}/${NEXT_PAGE}`, hasNextPage, nextPageToken })
 export const setUnreadMentionCount = (count) => ({ type: `${SET}/${UNREAD_MENTION_COUNT}`, count })

--- a/frontend/src/component/GroupedNotificationItem/GroupRender.jsx
+++ b/frontend/src/component/GroupedNotificationItem/GroupRender.jsx
@@ -14,6 +14,13 @@ import {
   Icon,
   formatAbsoluteDate
 } from 'tracim_frontend_lib'
+import {
+  putNotificationListAsRead
+} from '../../action-creator.async.js'
+import {
+  newFlashMessage,
+  readNotificationList
+} from '../../action-creator.sync.js'
 import { escape as escapeHtml, uniqBy } from 'lodash'
 
 const GroupRender = props => {
@@ -29,24 +36,19 @@ const GroupRender = props => {
   const numberOfWorkspaces = uniqBy(groupedNotifications.group.map(notification => notification.workspace), 'id').length
   const readStatus = groupedNotifications.group.map(notification => notification.read).reduce((acc, current) => acc && current)
 
-  // FIXME - MP - 14-03-2022 - Function removed so I can safely push
-  // However this is a regression, we can't put a group notification as read
-  // Issue : https://github.com/tracim/tracim/issues/5526
-  const handleReadGroupNotification = async (groupNotification) => {
-    //   // TODO - MP - 14-03-2022
-    //   // Create a props.dispatch(putGroupNotificationsAsRead(props.user.userId, groupNotification.group))
-    //   // Where it will read every notification in groupNotification.group
-    //   // related to https://github.com/tracim/tracim/issues/5526
-    //
-    //   const fetchPutNotificationAsRead = { status = 404 }
-    //   switch (fetchPutNotificationAsRead.status) {
-    //     case 204: {
-    //       props.dispatch(readGroupNotification(notificationId))
-    //       break
-    //     }
-    //     default:
-    //       props.dispatch(newFlashMessage(props.t('Error while marking the notification as read'), 'warning'))
-    //   }
+  const handleReadNotificationGroup = async (groupNotification) => {
+    const notificationIdList = groupNotification.group.map(notification => notification.id)
+    const fetchPutNotificationGroupAsRead = await props.dispatch(
+      putNotificationListAsRead(props.user.userId, notificationIdList)
+    )
+    switch (fetchPutNotificationGroupAsRead.status) {
+      case 204: {
+        props.dispatch(readNotificationList(notificationIdList))
+        break
+      }
+      default:
+        props.dispatch(newFlashMessage(props.t('Error while marking the notification as read'), 'warning'))
+    }
   }
 
   return (
@@ -111,7 +113,11 @@ const GroupRender = props => {
         {!readStatus &&
           <i
             className='notification__list__item__circle fas fa-circle'
-            onClick={() => handleReadGroupNotification(groupedNotifications)}
+            onClick={(e) => {
+              handleReadNotificationGroup(groupedNotifications)
+              e.preventDefault()
+              e.stopPropagation()
+            }}
           />}
       </div>
     </Link>

--- a/frontend/src/container/NotificationWall.jsx
+++ b/frontend/src/container/NotificationWall.jsx
@@ -9,7 +9,7 @@ import {
 import {
   appendNotificationList,
   newFlashMessage,
-  readNotificationList,
+  readEveryNotifications,
   setNextPage
 } from '../action-creator.sync.js'
 import {
@@ -245,7 +245,7 @@ export const NotificationWall = props => {
     const fetchAllPutNotificationAsRead = await props.dispatch(putAllNotificationAsRead(props.user.userId))
     switch (fetchAllPutNotificationAsRead.status) {
       case 204:
-        props.dispatch(readNotificationList())
+        props.dispatch(readEveryNotifications())
         break
       default:
         props.dispatch(newFlashMessage(props.t('An error has happened while setting "mark all as read"'), 'warning'))

--- a/frontend/test/src/container/NotificationWall.spec.js
+++ b/frontend/test/src/container/NotificationWall.spec.js
@@ -171,7 +171,7 @@ describe('<NotificationWall />', () => {
   })
 
   describe('handleClickMarkAllAsRead', () => {
-    it('should call readNotificationList()', (done) => {
+    it('should call readEveryNotifications()', (done) => {
       mockPutAllNotificationAsRead204(FETCH_CONFIG.apiUrl, props.user.userId, 1)
       NotificationWallInstance.handleClickMarkAllAsRead().then(() => {
         expect(readNotificationListCallBack.called).to.equal(true)

--- a/frontend/test/src/reducer/notificationPage.spec.js
+++ b/frontend/test/src/reducer/notificationPage.spec.js
@@ -11,7 +11,7 @@ import {
   READ,
   readContentNotification,
   readNotification,
-  readNotificationList,
+  readEveryNotifications,
   SET,
   setNextPage,
   UPDATE,
@@ -158,7 +158,7 @@ describe('reducer notificationPage.js', () => {
     })
 
     describe(`${READ}/${NOTIFICATION_LIST}`, () => {
-      const listOfNotification = notificationPage({ ...initialState, list: [notification], unreadNotificationCount: 1 }, readNotificationList())
+      const listOfNotification = notificationPage({ ...initialState, list: [notification], unreadNotificationCount: 1 }, readEveryNotifications())
 
       it('should return the list of objects passed as parameter', () => {
         expect(listOfNotification).to.deep.equal({ ...initialState, list: [{ ...notification, read: true }], unreadNotificationCount: 0 })


### PR DESCRIPTION
Issue ref #5526

This PR also bring:
- Update of `messages/read` endpoint: now you can pass a list of notification to read, this was required since a notification group is a frontend entity
- Deprecate `messages/{event_id}/read` to use `messages/read` so we don't have to maintain the code twice, remove duplicated logic

<!-- Here, you can write a short summary of what the pull request brings. If a related issue exists, please reference it here -->

## Checkpoints

<!-- These points must be checked before merging. Please don't edit them out. -->

**For developers**

- [ ] If relevant, manual tests have been done to ensure the stability of the whole application and that the involved feature works
- [ ] The original issue is up to date w.r.t the latest discussions and contains a short summary of the implemented solution
- [ ] Automated tests covering the feature or the fix, have been written, deemed irrelevant (give the reason), or an issue has been created to implement the test (give the link)
- [ ] Make sure that:
  - if there are modifications in the Tracim configuration files (eg. `development.ini`), they are documented in `backend/doc/setting.md`
  - any migration process required for existing instances is documented
  - relevant people for these changes are notified
- [ ] Original authors of the features included in a multi-feature branch (maintenance fixes -> develop, security fixes -> develop, …) should be part of the reviewers, especially if you encountered merge conflicts.

**For code reviewers**

- [ ] The code is clear enough
- [ ] If there are FIXMEs in the code, related issues are mentioned in the FIXME
- [ ] If there are TODOs, NOTEs or HACKs in code, the date and the developer initials are present

**For testers**

- [ ] Manual, quality tests have been done
