### PR TITLE
[DO NOT MERGE] test last version of pip for ci

### DIFF
--- a/backend/requirements-build.txt
+++ b/backend/requirements-build.txt
@@ -1,5 +1,5 @@
 # Build dependencies, to be installed before installing
 # others packages
-pip==21.1.3
+pip==22.2.2
 setuptools==57.0.0
 wheel==0.36.2


### PR DESCRIPTION
PR just for testing pip on CI to solved  (CI stuck since 4h30)
```
25hINFO: pip is looking at multiple versions of numpy to determine which version is compatible with other requirements. This could take a while.

INFO: pip is looking at multiple versions of rawpy to determine which version is compatible with other requirements. This could take a while.

INFO: pip is looking at multiple versions of future to determine which version is compatible with other requirements. This could take a while.

INFO: pip is looking at multiple versions of ffmpeg-python to determine which version is compatible with other requirements. This could take a while.

INFO: pip is looking at multiple versions of xvfbwrapper to determine which version is compatible with other requirements. This could take a while.

INFO: pip is looking at multiple versions of vtk to determine which version is compatible with other requirements. This could take a while.

INFO: pip is looking at multiple versions of flake8-isort to determine which version is compatible with other requirements. This could take a while.

Collecting flake8-isort==4.0.0

  Using cached flake8_isort-4.0.0-py2.py3-none-any.whl (14 kB)

INFO: pip is looking at multiple versions of flake8-black to determine which version is compatible with other requirements. This could take a while.

Collecting flake8-black==0.2.1

  Using cached flake8_black-0.2.1-py3-none-any.whl (8.9 kB)

INFO: pip is looking at multiple versions of black to determine which version is compatible with other requirements. This could take a while.

Collecting black==19.10b0

  Using cached black-19.10b0-py36-none-any.whl (97 kB)

INFO: pip is looking at multiple versions of numpy to determine which version is compatible with other requirements. This could take a while.

INFO: pip is looking at multiple versions of rawpy to determine which version is compatible with other requirements. This could take a while.

INFO: pip is looking at multiple versions of future to determine which version is compatible with other requirements. This could take a while.

INFO: pip is looking at multiple versions of ffmpeg-python to determine which version is compatible with other requirements. This could take a while.

INFO: pip is looking at multiple versions of xvfbwrapper to determine which version is compatible with other requirements. This could take a while.

INFO: pip is looking at multiple versions of vtk to determine which version is compatible with other requirements. This could take a while.

INFO: pip is looking at multiple versions of flake8-isort to determine which version is compatible with other requirements. This could take a while.

INFO: pip is looking at multiple versions of pre-commit to determine which version is compatible with other requirements. This could take a while.

INFO: pip is looking at multiple versions of mypy to determine which version is compatible with other requirements. This could take a while.

Collecting mypy==0.770

  Using cached mypy-0.770-py3-none-any.whl (1.9 MB)

INFO: This is taking longer than usual. You might need to provide the dependency resolver with stricter constraints to reduce runtime. If you want to abort this run, you can press Ctrl + C to do so. To improve how pip performs, tell us what happened here: https://pip.pypa.io/surveys/backtracking

INFO: This is taking longer than usual. You might need to provide the dependency resolver with stricter constraints to reduce runtime. If you want to abort this run, you can press Ctrl + C to do so. To improve how pip performs, tell us what happened here: https://pip.pypa.io/surveys/backtracking

INFO: This is taking longer than usual. You might need to provide the dependency resolver with stricter constraints to reduce runtime. If you want to abort this run, you can press Ctrl + C to do so. To improve how pip performs, tell us what happened here: https://pip.pypa.io/surveys/backtracking

INFO: This is taking longer than usual. You might need to provide the dependency resolver with stricter constraints to reduce runtime. If you want to abort this run, you can press Ctrl + C to do so. To improve how pip performs, tell us what happened here: https://pip.pypa.io/surveys/backtracking

INFO: This is taking longer than usual. You might need to provide the dependency resolver with stricter constraints to reduce runtime. If you want to abort this run, you can press Ctrl + C to do so. To improve how pip performs, tell us what happened here: https://pip.pypa.io/surveys/backtracking

INFO: This is taking longer than usual. You might need to provide the dependency resolver with stricter constraints to reduce runtime. If you want to abort this run, you can press Ctrl + C to do so. To improve how pip performs, tell us what happened here: https://pip.pypa.io/surveys/backtracking

INFO: This is taking longer than usual. You might need to provide the dependency resolver with stricter constraints to reduce runtime. If you want to abort this run, you can press Ctrl + C to do so. To improve how pip performs, tell us what happened here: https://pip.pypa.io/surveys/backtracking

INFO: pip is looking at multiple versions of flake8-black to determine which version is compatible with other requirements. This could take a while.

INFO: pip is looking at multiple versions of isort to determine which version is compatible with other requirements. This could take a while.

Collecting isort==4.3.21

  Using cached isort-4.3.21-py2.py3-none-any.whl (42 kB)

INFO: This is taking longer than usual. You might need to provide the dependency resolver with stricter constraints to reduce runtime. If you want to abort this run, you can press Ctrl + C to do so. To improve how pip performs, tell us what happened here: https://pip.pypa.io/surveys/backtracking

INFO: pip is looking at multiple versions of black to determine which version is compatible with other requirements. This could take a while.

INFO: pip is looking at multiple versions of flake8 to determine which version is compatible with other requirements. This could take a while.

Collecting flake8==3.7.9

  Using cached flake8-3.7.9-py2.py3-none-any.whl (69 kB)

INFO: This is taking longer than usual. You might need to provide the dependency resolver with stricter constraints to reduce runtime. If you want to abort this run, you can press Ctrl + C to do so. To improve how pip performs, tell us what happened here: https://pip.pypa.io/surveys/backtracking

INFO: pip is looking at multiple versions of pre-commit to determine which version is compatible with other requirements. This could take a while.

INFO: pip is looking at multiple versions of mypy to determine which version is compatible with other requirements. This could take a while.

INFO: pip is looking at multiple versions of sseclient-py to determine which version is compatible with other requirements. This could take a while.

Collecting sseclient-py==1.7

  Using cached sseclient_py-1.7-py2.py3-none-any.whl (5.4 kB)

INFO: This is taking longer than usual. You might need to provide the dependency resolver with stricter constraints to reduce runtime. If you want to abort this run, you can press Ctrl + C to do so. To improve how pip performs, tell us what happened here: https://pip.pypa.io/surveys/backtracking

INFO: This is taking longer than usual. You might need to provide the dependency resolver with stricter constraints to reduce runtime. If you want to abort this run, you can press Ctrl + C to do so. To improve how pip performs, tell us what happened here: https://pip.pypa.io/surveys/backtracking

INFO: pip is looking at multiple versions of isort to determine which version is compatible with other requirements. This could take a while.

INFO: pip is looking at multiple versions of freezegun to determine which version is compatible with other requirements. This could take a while.

Collecting freezegun==0.3.12

  Using cached freezegun-0.3.12-py2.py3-none-any.whl (12 kB)

INFO: This is taking longer than usual. You might need to provide the dependency resolver with stricter constraints to reduce runtime. If you want to abort this run, you can press Ctrl + C to do so. To improve how pip performs, tell us what happened here: https://pip.pypa.io/surveys/backtracking

INFO: pip is looking at multiple versions of flake8 to determine which version is compatible with other requirements. This could take a while.

INFO: pip is looking at multiple versions of mock to determine which version is compatible with other requirements. This could take a while.

Collecting mock==3.0.5

  Using cached mock-3.0.5-py2.py3-none-any.whl (25 kB)

INFO: This is taking longer than usual. You might need to provide the dependency resolver with stricter constraints to reduce runtime. If you want to abort this run, you can press Ctrl + C to do so. To improve how pip performs, tell us what happened here: https://pip.pypa.io/surveys/backtracking

INFO: pip is looking at multiple versions of sseclient-py to determine which version is compatible with other requirements. This could take a while.

INFO: pip is looking at multiple versions of responses to determine which version is compatible with other requirements. This could take a while.

Collecting responses==0.10.11

  Using cached responses-0.10.11-py2.py3-none-any.whl (15 kB)

INFO: This is taking longer than usual. You might need to provide the dependency resolver with stricter constraints to reduce runtime. If you want to abort this run, you can press Ctrl + C to do so. To improve how pip performs, tell us what happened here: https://pip.pypa.io/surveys/backtracking

INFO: pip is looking at multiple versions of freezegun to determine which version is compatible with other requirements. This could take a while.

INFO: pip is looking at multiple versions of pytest-forked to determine which version is compatible with other requirements. This could take a while.

Collecting pytest-forked==1.3.0

  Using cached pytest_forked-1.3.0-py2.py3-none-any.whl (4.7 kB)

INFO: This is taking longer than usual. You might need to provide the dependency resolver with stricter constraints to reduce runtime. If you want to abort this run, you can press Ctrl + C to do so. To improve how pip performs, tell us what happened here: https://pip.pypa.io/surveys/backtracking

INFO: pip is looking at multiple versions of mock to determine which version is compatible with other requirements. This could take a while.

INFO: pip is looking at multiple versions of pytest-timeout to determine which version is compatible with other requirements. This could take a while.

Collecting pytest-timeout==1.4.2

  Using cached pytest_timeout-1.4.2-py2.py3-none-any.whl (10 kB)

INFO: This is taking longer than usual. You might need to provide the dependency resolver with stricter constraints to reduce runtime. If you want to abort this run, you can press Ctrl + C to do so. To improve how pip performs, tell us what happened here: https://pip.pypa.io/surveys/backtracking

INFO: pip is looking at multiple versions of responses to determine which version is compatible with other requirements. This could take a while.

INFO: pip is looking at multiple versions of pytest-testinfra to determine which version is compatible with other requirements. This could take a while.

Collecting pytest-testinfra==6.4.0

  Using cached pytest_testinfra-6.4.0-py3-none-any.whl (71 kB)

INFO: This is taking longer than usual. You might need to provide the dependency resolver with stricter constraints to reduce runtime. If you want to abort this run, you can press Ctrl + C to do so. To improve how pip performs, tell us what happened here: https://pip.pypa.io/surveys/backtracking

INFO: pip is looking at multiple versions of pytest-forked to determine which version is compatible with other requirements. This could take a while.

INFO: pip is looking at multiple versions of pytest-services to determine which version is compatible with other requirements. This could take a while.

Collecting pytest-services==2.0.1

  Using cached pytest_services-2.0.1-py3-none-any.whl (17 kB)

INFO: This is taking longer than usual. You might need to provide the dependency resolver with stricter constraints to reduce runtime. If you want to abort this run, you can press Ctrl + C to do so. To improve how pip performs, tell us what happened here: https://pip.pypa.io/surveys/backtracking

INFO: pip is looking at multiple versions of pytest-timeout to determine which version is compatible with other requirements. This could take a while.

INFO: pip is looking at multiple versions of pytest-dotenv to determine which version is compatible with other requirements. This could take a while.

Collecting pytest-dotenv==0.4.0

  Using cached pytest_dotenv-0.4.0-py3-none-any.whl (3.1 kB)

INFO: This is taking longer than usual. You might need to provide the dependency resolver with stricter constraints to reduce runtime. If you want to abort this run, you can press Ctrl + C to do so. To improve how pip performs, tell us what happened here: https://pip.pypa.io/surveys/backtracking

INFO: pip is looking at multiple versions of pytest-testinfra to determine which version is compatible with other requirements. This could take a while.

INFO: pip is looking at multiple versions of pytest to determine which version is compatible with other requirements. This could take a while.

Collecting pytest==5.3.5

  Using cached pytest-5.3.5-py3-none-any.whl (235 kB)

INFO: pip is looking at multiple versions of pytest-services to determine which version is compatible with other requirements. This could take a while.

Collecting WebTest==2.0.34

```