### PR TITLE
feat(frontend): displaying a more specific message if a file upload fails

### DIFF
--- a/frontend_lib/src/container/PopupUploadFile.jsx
+++ b/frontend_lib/src/container/PopupUploadFile.jsx
@@ -116,7 +116,9 @@ class PopupUploadFile extends React.Component {
       this.setState({
         fileUploadList: failedFileUploadList
       })
-      sendGlobalFlashMessage(props.t('Error while uploading file(s)'))
+      let message = props.t('Error while uploading file(s)')
+      if (failedFileUploadList.length === 1) message = failedFileUploadList[0].errorMessage
+      sendGlobalFlashMessage(message)
       props.onFailure(failedFileUploadList)
     } else props.onSuccess(successfulFileUploadList)
     this.setState({ uploadStarted: false })

--- a/functionnal_tests/cypress/integration/app_file/add_file_error_messages_spec.js
+++ b/functionnal_tests/cypress/integration/app_file/add_file_error_messages_spec.js
@@ -1,4 +1,4 @@
-import { PAGES as p } from "../../support/urls_commands";
+import { PAGES as p, URLS } from '../../support/urls_commands';
 import { SELECTORS as s } from '../../support/generic_selector_commands'
 
 const pngFile = 'artikodin.png'
@@ -36,9 +36,7 @@ describe('In a workspace', function () {
       .get('.previewcomponent').should('have.length', 1)
     cy.getTag({ selectorName: s.CONTENT_FRAME })
       .get('.selectStatus').contains('Opened')
-    cy.url().should('include', `/ui/workspaces/${workspaceId}/contents/file/`)
-
-    cy.visitPage({ pageName: p.DASHBOARD, params: { workspaceId: workspaceId } })
+    cy.url().should('include', URLS[p.FILE]({workspaceId, fileId: '1'}))
   })
 
   it('should display an error popup containing a descriptive error when uploading a single file', function () {
@@ -56,7 +54,7 @@ describe('In a workspace', function () {
     cy.get('.flashmessage__container__content__text__paragraph')
       .should('exist')
     cy.get('.flashmessage__container__content__text__paragraph')
-      .should('include.text', "already exists")
+      .should('include.text', 'already exists')
   })
 
   it('should display an error popup containing a descriptive error when uploading multiple files', function () {
@@ -78,7 +76,7 @@ describe('In a workspace', function () {
     cy.get('.flashmessage__container__content__text__paragraph')
       .should('exist')
     cy.get('.flashmessage__container__content__text__paragraph')
-      .should('include.text', "already exists")
+      .should('include.text', 'already exists')
   })
 
   it('should display an error popup containing a generic error when uploading multiple erroneous files', function () {
@@ -100,6 +98,6 @@ describe('In a workspace', function () {
     cy.get('.flashmessage__container__content__text__paragraph')
       .should('exist')
     cy.get('.flashmessage__container__content__text__paragraph')
-      .should('include.text', "Error while uploading file(s)")
+      .should('include.text', 'Error while uploading file(s)')
   })
 })

--- a/functionnal_tests/cypress/integration/app_file/add_file_error_messages_spec.js
+++ b/functionnal_tests/cypress/integration/app_file/add_file_error_messages_spec.js
@@ -1,0 +1,105 @@
+import { PAGES as p } from "../../support/urls_commands";
+import { SELECTORS as s } from '../../support/generic_selector_commands'
+
+const pngFile = 'artikodin.png'
+let workspaceId
+
+describe('In a workspace', function () {
+  before(() => {
+    cy.resetDB()
+    cy.setupBaseDB()
+    cy.loginAs('administrators')
+    cy.fixture('baseWorkspace').then(workspace => {
+      workspaceId = workspace.workspace_id
+    })
+  })
+
+  beforeEach(function () {
+    cy.loginAs('users')
+    cy.visitPage({ pageName: p.DASHBOARD, params: { workspaceId: workspaceId } })
+  })
+
+  afterEach(function () {
+    cy.cancelXHR()
+  })
+
+  it('should open the app file with the newly added file', function () {
+    cy.getTag({ selectorName: s.WORKSPACE_DASHBOARD })
+      .get('button[title="Upload files"]')
+      .click()
+
+    cy.dropFixtureInDropZone(pngFile, 'image/png', '.filecontent__form', 'file_exemple1.png')
+    cy.getTag({ selectorName: s.CARD_POPUP_BODY })
+      .get('[data-cy=popup__createcontent__form__button]')
+      .click()
+    cy.getTag({ selectorName: s.CONTENT_FRAME })
+      .get('.previewcomponent').should('have.length', 1)
+    cy.getTag({ selectorName: s.CONTENT_FRAME })
+      .get('.selectStatus').contains('Opened')
+    cy.url().should('include', `/ui/workspaces/${workspaceId}/contents/file/`)
+
+    cy.visitPage({ pageName: p.DASHBOARD, params: { workspaceId: workspaceId } })
+  })
+
+  it('should display an error popup containing a descriptive error when uploading a single file', function () {
+    cy.getTag({ selectorName: s.WORKSPACE_DASHBOARD })
+      .get('button[title="Upload files"]')
+      .click()
+
+    cy.dropFixtureInDropZone(pngFile, 'image/png', '.filecontent__form', 'file_exemple1.png')
+    cy.getTag({ selectorName: s.CARD_POPUP_BODY })
+      .get('[data-cy=popup__createcontent__form__button]')
+      .click()
+    cy.getTag({ selectorName: s.CARD_POPUP_BODY })
+      .get('[data-cy=popup__createcontent__form__button]')
+
+    cy.get('.flashmessage__container__content__text__paragraph')
+      .should('exist')
+    cy.get('.flashmessage__container__content__text__paragraph')
+      .should('include.text', "already exists")
+  })
+
+  it('should display an error popup containing a descriptive error when uploading multiple files', function () {
+    const fileName1 = 'png_exemple3'
+    const fileName2 = 'pdf_exemple3'
+
+    cy.createFile(pngFile, 'image/png', `${fileName1}.png`, workspaceId)
+
+    cy.getTag({ selectorName: s.WORKSPACE_DASHBOARD })
+      .get('button[title="Upload files"]')
+      .click()
+
+    cy.dropFixtureInDropZone(pngFile, 'image/png', '.filecontent__form', `${fileName1}.png`)
+    cy.dropFixtureInDropZone(pngFile, 'image/png', '.filecontent__form', `${fileName2}.png`)
+    cy.getTag({ selectorName: s.CARD_POPUP_BODY })
+      .get('[data-cy=popup__createcontent__form__button]')
+      .click()
+
+    cy.get('.flashmessage__container__content__text__paragraph')
+      .should('exist')
+    cy.get('.flashmessage__container__content__text__paragraph')
+      .should('include.text', "already exists")
+  })
+
+  it('should display an error popup containing a generic error when uploading multiple erroneous files', function () {
+    const fileName1 = 'png_exemple3'
+    const fileName2 = 'pdf_exemple3'
+
+    cy.createFile(pngFile, 'image/png', `${fileName1}.png`, workspaceId)
+
+    cy.getTag({ selectorName: s.WORKSPACE_DASHBOARD })
+      .get('button[title="Upload files"]')
+      .click()
+
+    cy.dropFixtureInDropZone(pngFile, 'image/png', '.filecontent__form', `${fileName1}.png`)
+    cy.dropFixtureInDropZone(pngFile, 'image/png', '.filecontent__form', `${fileName2}.png`)
+    cy.getTag({ selectorName: s.CARD_POPUP_BODY })
+      .get('[data-cy=popup__createcontent__form__button]')
+      .click()
+
+    cy.get('.flashmessage__container__content__text__paragraph')
+      .should('exist')
+    cy.get('.flashmessage__container__content__text__paragraph')
+      .should('include.text', "Error while uploading file(s)")
+  })
+})

--- a/functionnal_tests/cypress/support/urls_commands.js
+++ b/functionnal_tests/cypress/support/urls_commands.js
@@ -18,7 +18,8 @@ const PAGES = {
   PUBLICATION: 'publication',
   PROFILE: 'profile',
   WORKSPACE_RECENT_ACTIVITIES: 'workspaceRecentActivities',
-  FAVORITES: 'favorites'
+  FAVORITES: 'favorites',
+  FILE: 'file'
 }
 
 const URLS = {
@@ -41,7 +42,8 @@ const URLS = {
   [PAGES.RECENT_ACTIVITIES]: () => '/ui/recent-activities',
   [PAGES.PUBLICATION]: ({ workspaceId }) => `/ui/workspaces/${workspaceId}/publications`,
   [PAGES.PROFILE]: ({ userId }) => `/ui/users/${userId}/profile`,
-  [PAGES.FAVORITES]: () => 'ui/favorites'
+  [PAGES.FAVORITES]: () => 'ui/favorites',
+  [PAGES.FILE]: ({ workspaceId, fileId }) => `/ui/workspaces/${workspaceId}/contents/file/${fileId}`
 }
 
 /**


### PR DESCRIPTION
#3497
Now displaying a more specific message if a file upload fails, note that in the case of more than one erroneous file the generic message is displayed. This is also the case when XHR crashes.

<!-- Here, you can write a short summary of what the pull request brings. If a related issue exists, please reference it here -->

## Checkpoints

<!-- These points must be checked before merging. Please don't edit them out. -->

**For developers**

- [x] If relevant, manual tests have been done to ensure the stability of the whole application and that the involved feature works
- [x] The original issue is up to date w.r.t the latest discussions and contains a short summary of the implemented solution
- [x] Automated tests covering the feature or the fix, have been written, deemed irrelevant (give the reason), or an issue has been created to implement the test (give the link)
- [x] Make sure that:
  - if there are modifications in the Tracim configuration files (eg. `development.ini`), they are documented in `backend/doc/setting.md`
  - any migration process required for existing instances is documented
  - relevant people for these changes are notified
- [x] Original authors of the features included in a multi-feature branch (maintenance fixes -> develop, security fixes -> develop, …) should be part of the reviewers, especially if you encountered merge conflicts.

**For code reviewers**

- [x] The code is clear enough
- [x] If there are FIXMEs in the code, related issues are mentioned in the FIXME
- [x] If there are TODOs, NOTEs or HACKs in code, the date and the developer initials are present

**For testers**

- [x] Manual, quality tests have been done
