### PR TITLE
fix(frontend): do not display task notification if you are not the assignee

### DIFF
--- a/backend/tracim_backend/lib/core/content.py
+++ b/backend/tracim_backend/lib/core/content.py
@@ -2047,12 +2047,12 @@ class ContentApi(object):
         if do_notify:
             self.do_notify(content)
 
-    def do_notify(self, content: Content):
+    def do_notify(self, content: Content) -> None:
         """
-        Allow to force notification for a given content. By default, it is
-        called during the .save() operation
-        :param content:
-        :return:
+        Create a notification -mail- and notify the current user
+
+        Args:
+            content (Content): Content that the notification will be about
         """
         NotifierFactory.create(
             config=self._config, current_user=self._user, session=self._session
@@ -2242,8 +2242,20 @@ class ContentApi(object):
             self._session.flush()
 
     def create_todo(
-        self, parent: Content, assignee: User, raw_content: str, do_notify: bool = True,
+        self, parent: Content, assignee: User, raw_content: str, do_notify: bool = True
     ) -> Content:
+        """Create a todo in the database.
+
+        Args:
+            parent (Content): Parent content of the Todo. By our definition, a Todo can only exist \
+                if it got a parent.
+            assignee (User): User assigned to the Todo. Can be `None` if the Todo has no assignee.
+            raw_content (str): Text of the Todo.
+            do_notify (bool, optional): Notify everyone. Defaults to False.
+
+        Returns:
+            Content: The created Todo.
+        """
         item = self.create(
             content_namespace=parent.content_namespace,
             content_type_slug=content_type_list.Todo.slug,

--- a/backend/tracim_backend/lib/core/event.py
+++ b/backend/tracim_backend/lib/core/event.py
@@ -905,7 +905,8 @@ def _get_members_and_administrators_ids(
     event: Event, session: TracimSession, config: CFG
 ) -> Set[int]:
     """
-    Return administrators + members of the event's workspace + user subject of the action if there is one
+    Return administrators + members of the event's workspace + user subject of the action if there\
+        is one
     """
     user_api = UserApi(current_user=None, session=session, config=config)
     administrators = user_api.get_user_ids_from_profile(Profile.ADMIN)
@@ -958,7 +959,15 @@ def _get_workspace_subscription_event_receiver_ids(
 
 def _get_content_event_receiver_ids(event: Event, session: TracimSession, config: CFG) -> Set[int]:
     """
-    Content event are returned to workspace members only
+    Content event are returned to workspace members only.
+
+    Args:
+        event (Event): Event that will be sent
+        session (TracimSession): Current session
+        config (CFG): Config file
+
+    Returns:
+        Set[int]: List of user id that will receive the event
     """
     role_api = RoleApi(current_user=None, session=session, config=config)
     workspace_members = role_api.get_workspace_member_ids(event.workspace_id)
@@ -981,15 +990,15 @@ class BaseLiveMessageBuilder(abc.ABC):
     _event_schema = EventSchema()
 
     _get_receiver_ids_callables = {
-        EntityType.USER: _get_user_event_receiver_ids,
-        EntityType.WORKSPACE: _get_workspace_event_receiver_ids,
-        EntityType.WORKSPACE_MEMBER: _get_members_and_administrators_ids,
+        EntityType.CONTENT_TAG: _get_content_event_receiver_ids,
         EntityType.CONTENT: _get_content_event_receiver_ids,
-        EntityType.WORKSPACE_SUBSCRIPTION: _get_workspace_subscription_event_receiver_ids,
         EntityType.REACTION: _get_content_event_receiver_ids,
         EntityType.TAG: _get_workspace_event_receiver_ids,
-        EntityType.CONTENT_TAG: _get_content_event_receiver_ids,
         EntityType.USER_CALL: _get_user_call_event_receiver_ids,
+        EntityType.USER: _get_user_event_receiver_ids,
+        EntityType.WORKSPACE_MEMBER: _get_members_and_administrators_ids,
+        EntityType.WORKSPACE_SUBSCRIPTION: _get_workspace_subscription_event_receiver_ids,
+        EntityType.WORKSPACE: _get_workspace_event_receiver_ids,
     }  # type: Dict[str, GetReceiverIdsCallable]
 
     def __init__(self, config: CFG) -> None:
@@ -1025,7 +1034,7 @@ class BaseLiveMessageBuilder(abc.ABC):
             session = context.dbsession
             event = session.query(Event).filter(Event.event_id == event_id).one()
             receiver_ids = self.get_receiver_ids(event, session, self._config)
-            logger.debug(self, "Sending messages for event {} to {}".format(event, receiver_ids))
+            logger.debug(self, "Sending eventid: {} to users: {}".format(event_id, receiver_ids))
             messages = [
                 Message(
                     receiver_id=receiver_id,

--- a/frontend/src/action-creator.sync.js
+++ b/frontend/src/action-creator.sync.js
@@ -202,8 +202,17 @@ export const NOTIFICATION_LIST = 'NotificationList'
 export const NOTIFICATION = 'Notification'
 export const UNREAD_MENTION_COUNT = 'UnreadMentionCount'
 export const UNREAD_NOTIFICATION_COUNT = 'UnreadNotificationCount'
-export const appendNotificationList = (notificationList, spaceList) => ({ type: `${APPEND}/${NOTIFICATION_LIST}`, notificationList, spaceList })
-export const addNotification = (notification, spaceList) => ({ type: `${ADD}/${NOTIFICATION}`, notification, spaceList })
+export const appendNotificationList = (userId, notificationList, spaceList) => ({
+  type: `${APPEND}/${NOTIFICATION_LIST}`,
+  userId,
+  notificationList,
+  spaceList
+})
+export const addNotification = (notification, spaceList) => ({
+  type: `${ADD}/${NOTIFICATION}`,
+  notification,
+  spaceList
+})
 export const updateNotification = (notificationId, notificationList) => ({ type: `${UPDATE}/${NOTIFICATION}`, notificationId, notificationList })
 export const readNotification = notificationId => ({ type: `${READ}/${NOTIFICATION}`, notificationId })
 export const readNotificationList = () => ({ type: `${READ}/${NOTIFICATION_LIST}` })

--- a/frontend/src/container/NotificationWall.jsx
+++ b/frontend/src/container/NotificationWall.jsx
@@ -267,7 +267,13 @@ export const NotificationWall = props => {
           // INFO - MP - 2022-05-23 - We need to set the next page first and update the list of notifications
           // after, so the hook isn't triggered too early.
           props.dispatch(setNextPage(fetchGetNotificationWall.json.has_next, fetchGetNotificationWall.json.next_page_token))
-          props.dispatch(appendNotificationList(fetchGetNotificationWall.json.items, props.workspaceList))
+          props.dispatch(
+            appendNotificationList(
+              props.user.userId,
+              fetchGetNotificationWall.json.items,
+              props.workspaceList
+            )
+          )
           break
         default:
           props.dispatch(newFlashMessage(props.t('Error while loading the notification list'), 'warning'))

--- a/frontend/src/container/ReduxTlmDispatcher.jsx
+++ b/frontend/src/container/ReduxTlmDispatcher.jsx
@@ -109,11 +109,12 @@ export class ReduxTlmDispatcher extends React.Component {
   }
 
   handleNotification = data => {
+    const { props } = this
     if (
-      this.props.user.userId !== data.fields.author.user_id &&
+      props.user.userId !== data.fields.author.user_id &&
       !EXCLUDED_NOTIFICATION_TYPE_PREFIXES.some(type => data.event_type.startsWith(type))
     ) {
-      this.props.dispatch(addNotification(data, this.props.workspaceList))
+      props.dispatch(addNotification(data, props.workspaceList))
     }
   }
 
@@ -143,7 +144,15 @@ export class ReduxTlmDispatcher extends React.Component {
 
   handleWorkspaceChanged = this.handleNotification
 
-  handleToDo = this.handleNotification
+  handleToDo = data => {
+    if (data.fields.content.assignee.username) {
+      if (data.fields.content.assignee.user_id === this.props.user.userId) {
+        this.handleNotification(data)
+      }
+    } else {
+      this.handleNotification(data)
+    }
+  }
 
   handleMemberCreated = data => {
     const { props } = this
@@ -323,7 +332,9 @@ export class ReduxTlmDispatcher extends React.Component {
   }
 
   handleUserChanged = data => {
-    this.props.dispatch(addNotification(data, this.props.workspaceList))
+    const { props } = this
+
+    this.props.dispatch(addNotification(data, props.workspaceList))
   }
 
   handleWorkspaceSubscriptionCreated = data => {

--- a/frontend/src/reducer/notificationPage.js
+++ b/frontend/src/reducer/notificationPage.js
@@ -99,12 +99,12 @@ function notificationListDisplayFilter (
 ) {
   let newUnreadNotificationCount = unreadNotificationCount
   const newNotificationList = notificationList.map((notification) => {
-    const [entityType, , subTpe] = notification.type.split('.')
+    const [entityType, , subType] = notification.type.split('.')
 
     // NOTE - MP - 2022-10-18 - Since we are filtering twice, the -1 verification is if we are
     // doing this function in the `addNotification` case, which in this case is already filtered
     if (userId !== -1) {
-      if (entityType === TLM_ET.CONTENT && subTpe === TLM_ST.TODO) {
+      if (entityType === TLM_ET.CONTENT && subType === TLM_ST.TODO) {
         if (notification.content.assignee.username) {
           if (notification.content.assignee.userId !== userId) {
             if (!notification.read) newUnreadNotificationCount--

--- a/frontend/src/reducer/notificationPage.js
+++ b/frontend/src/reducer/notificationPage.js
@@ -84,8 +84,7 @@ function getMainContentId (notification) {
  * in withActivity and ActivityList, and can be refactor
  * See https://github.com/tracim/tracim/issues/4677
  * FIXME - MP - 2022-10-18 - This function allows us to filter when loading more notifications.
- * Therefore there is a similar loginc in ReduxTlmDispatcher.js
- * We should filter in backend instead.
+ * However there is a similar loginc in ReduxTlmDispatcher.js when we receive a TLM.
  * https://github.com/tracim/tracim/issues/5946
  *
  * Filter the notification list
@@ -153,7 +152,7 @@ export default function notificationPage (state = defaultNotificationsObject, ac
         ...state,
         unreadMentionCount: newUnreadMentionCount,
         // FIXME - MP - 2022-10-18 - Remove the function here to keep the logic in
-        // ReduxTlmDispatcher or in the backend
+        // ReduxTlmDispatcher.jsx
         // https://github.com/tracim/tracim/issues/5946
         ...notificationListDisplayFilter(
           -1,

--- a/frontend/src/reducer/notificationPage.js
+++ b/frontend/src/reducer/notificationPage.js
@@ -49,12 +49,12 @@ export const serializeNotification = notification => {
       author: serialize(notification.fields.subscription.author, serializeUserProps)
     } : null,
     content: notification.fields.content ? {
-      parentLabel: notification.fields.content.parent ?
-        notification.fields.content.parent.label : null,
-      parentId: notification.fields.content.parent ?
-        notification.fields.content.parent.content_id : null,
-      assignee: notification.fields.content.assignee ?
-        serialize(notification.fields.content.assignee, serializeUserProps) : null,
+      parentLabel: notification.fields.content.parent
+        ? notification.fields.content.parent.label : null,
+      parentId: notification.fields.content.parent
+        ? notification.fields.content.parent.content_id : null,
+      assignee: notification.fields.content.assignee
+        ? serialize(notification.fields.content.assignee, serializeUserProps) : null,
       ...serialize(notification.fields.content, serializeContentProps)
     } : null,
     created: notification.created,

--- a/frontend/test/src/reducer/notificationPage.spec.js
+++ b/frontend/test/src/reducer/notificationPage.spec.js
@@ -168,12 +168,16 @@ describe('reducer notificationPage.js', () => {
     describe(`${APPEND}/${NOTIFICATION_LIST}`, () => {
       const listOfNotification = notificationPage(
         { ...initialState, list: [notification] },
-        appendNotificationList([{ ...TLM, event_id: 999 }], workspaceList.workspaceList)
+        appendNotificationList(-1, [{ ...TLM, event_id: 999 }], workspaceList.workspaceList)
       )
 
-      it('should return the list of notifications appended with the list passed as parameter', () => {
-        expect(listOfNotification).to.deep.equal({ ...initialState, list: [notification, { ...notification, id: 999 }] })
-      })
+      it('should return the list of notifications appended with the list passed as parameter',
+        () => {
+          expect(listOfNotification).to.deep.equal(
+            { ...initialState, list: [notification, { ...notification, id: 999 }] }
+          )
+        }
+      )
     })
 
     describe(`${SET}/${NEXT_PAGE}`, () => {


### PR DESCRIPTION
Issue #5940

The filter is done only in the client (frontend) twice.
An issue has been created to uniform the filters (see #5946).

## Checkpoints

<!-- These points must be checked before merging. Please don't edit them out. -->

**For developers**

- [x] If relevant, manual tests have been done to ensure the stability of the whole application and that the involved feature works
- [x] The original issue is up to date w.r.t the latest discussions and contains a short summary of the implemented solution
- [x] Automated tests covering the feature or the fix, have been written, deemed irrelevant (give the reason), or an issue has been created to implement the test (give the link)
- [x] Make sure that:
  - if there are modifications in the Tracim configuration files (eg. `development.ini`), they are documented in `backend/doc/setting.md`
  - any migration process required for existing instances is documented
  - relevant people for these changes are notified
- [x] Original authors of the features included in a multi-feature branch (maintenance fixes -> develop, security fixes -> develop, …) should be part of the reviewers, especially if you encountered merge conflicts.

**For code reviewers**

- [x] The code is clear enough
- [x] If there are FIXMEs in the code, related issues are mentioned in the FIXME
- [x] If there are TODOs, NOTEs or HACKs in code, the date and the developer initials are present

**For testers**

- [x] Manual, quality tests have been done
