### PR TITLE
fix(frontend): No content preview on news when it's content is a file in the dashboard

### DIFF
--- a/frontend/src/container/FeedItemWithPreview.jsx
+++ b/frontend/src/container/FeedItemWithPreview.jsx
@@ -324,6 +324,9 @@ export class FeedItemWithPreview extends React.Component {
         ? this.getFirstComment()
         : null
     )
+    if (shouldShowComment && props.inRecentActivities) {
+      props.content.firstComment = commentToShow
+    }
 
     const commentList = this.getTimelineData()
 

--- a/functionnal_tests/cypress/integration/activity_feed/activity_spec.js
+++ b/functionnal_tests/cypress/integration/activity_feed/activity_spec.js
@@ -36,4 +36,19 @@ describe('At the space recent activities page', () => {
       cy.url().should('include', URLS[PAGES.PROFILE]({ userId: user.user_id }))
     })
   })
+
+  describe("a news with a file as it's only content", () => {
+    it("should create a news with a file as it's only content", () => {
+      cy.visitPage({ pageName: PAGES.WORKSPACE_RECENT_ACTIVITIES, params: { workspaceId }, waitForTlm: true })
+      cy.get('[data-cy=create_news]').click()
+      cy.get('.publishArea__texteditor__submit > div > .iconbutton-secondary-dark').click()
+      cy.dropFixtureInDropZone(fullFilename, 'image/png', '.filecontent__form', `${fileTitle}.png`)
+      cy.get('[data-cy=popup__createcontent__form__button]').click()
+      cy.get('[data-cy=commentArea__comment__send]').click()
+    })
+    it('should display the file preview', () => {
+      cy.get('[data-cy=FilenameWithBadges__label]').first().should('include.text', 'News')
+      cy.get('.CommentFilePreview > .attachedFile').should('be.visible')
+    })
+  })
 })


### PR DESCRIPTION
#5939
<!-- Here, you can write a short summary of what the pull request brings. If a related issue exists, please reference it here -->

## Checkpoints

<!-- These points must be checked before merging. Please don't edit them out. -->

**For developers**

- [x] If relevant, manual tests have been done to ensure the stability of the whole application and that the involved feature works
- [x] The original issue is up to date w.r.t the latest discussions and contains a short summary of the implemented solution
- [x] Automated tests covering the feature or the fix, have been written, deemed irrelevant (give the reason), or an issue has been created to implement the test (give the link)
- [x] Make sure that:
  - if there are modifications in the Tracim configuration files (eg. `development.ini`), they are documented in `backend/doc/setting.md`
  - any migration process required for existing instances is documented
  - relevant people for these changes are notified
- [x] Original authors of the features included in a multi-feature branch (maintenance fixes -> develop, security fixes -> develop, …) should be part of the reviewers, especially if you encountered merge conflicts.

**For code reviewers**

- [x] The code is clear enough
- [x] If there are FIXMEs in the code, related issues are mentioned in the FIXME
- [x] If there are TODOs, NOTEs or HACKs in code, the date and the developer initials are present

**For testers**

- [x] Manual, quality tests have been done
