### PR TITLE
fix(front): add emoji library using the cache token and the csp

### DIFF
--- a/frontend/dist/index.mak
+++ b/frontend/dist/index.mak
@@ -151,6 +151,10 @@
     <script type="text/javascript" src="/${plugin}?token=${cache_token}" nonce="${csp_nonce}"></script>
     %endfor
 
+    ## INFO - CH - 20221108 - hardcode the emoji library script because otherwise, it is loaded on the fly by the emoticons plugin
+    ## but doesn't include the cache_token and the csp_nonce. The script would then be blocked by browsers
+    <script type="text/javascript" src="/assets/tinymce-5.10.3/js/tinymce/plugins/emoticons/js/emojis.min.js?token=${cache_token}" nonce="${csp_nonce}"></script>
+
     % for lang in glob("assets/tinymce-5.10.3/js/tinymce/langs/*.js"):
     <script type="text/javascript" src="/${lang}?token=${cache_token}" nonce="${csp_nonce}"></script>
     %endfor


### PR DESCRIPTION
<!-- Here, you can write a short summary of what the pull request brings. If a related issue exists, please reference it here -->
https://github.com/tracim/tracim/issues/6006
This pr fixes an issue from https://github.com/tracim/tracim/pull/6010

The issue was that the emoji library from tinymce was loading the emoji database on the fly upon clicking on the emoji button. But was trying to load the library without including the csp and got blocked

## Checkpoints

<!-- These points must be checked before merging. Please don't edit them out. -->

**For developers**

- [x] If relevant, manual tests have been done to ensure the stability of the whole application and that the involved feature works
- [x] The original issue is up to date w.r.t the latest discussions and contains a short summary of the implemented solution
~- [ ] Automated tests covering the feature or the fix, have been written, deemed irrelevant (give the reason), or an issue has been created to implement the test (give the link)~
- [x] Make sure that:
  - if there are modifications in the Tracim configuration files (eg. `development.ini`), they are documented in `backend/doc/setting.md`
  - any migration process required for existing instances is documented
  - relevant people for these changes are notified
- [x] Original authors of the features included in a multi-feature branch (maintenance fixes -> develop, security fixes -> develop, …) should be part of the reviewers, especially if you encountered merge conflicts.

**For code reviewers**

- [x] The code is clear enough
- [x] If there are FIXMEs in the code, related issues are mentioned in the FIXME
- [x] If there are TODOs, NOTEs or HACKs in code, the date and the developer initials are present

**For testers**

- [x] Manual, quality tests have been done
