### PR TITLE
Fix(backend, frontend): reduce the number of communication during a copy from webdav

### DIFF
--- a/backend/tracim_backend/hookspec.py
+++ b/backend/tracim_backend/hookspec.py
@@ -10,6 +10,7 @@ from tracim_backend.config import CFG
 from tracim_backend.lib.core.plugins import hookspec
 from tracim_backend.lib.utils.request import TracimContext
 from tracim_backend.models.auth import User
+from tracim_backend.models.event import OperationType
 from tracim_backend.models.tracim_session import TracimSession
 
 
@@ -19,6 +20,15 @@ class TracimContextHookSpec:
     Don't assume that there is only one active context at one point in time if
     the WSGI app is launched with threads.
     """
+
+    @hookspec
+    def on_batched_events_finished(
+        self, operation_type: OperationType, obj: object, context: TracimContext
+    ) -> None:
+        """
+        Called when batched_events context manager is finished.
+        """
+        pass
 
     @hookspec
     def on_context_current_user_set(self, user: User, context: TracimContext) -> None:

--- a/backend/tracim_backend/lib/core/event.py
+++ b/backend/tracim_backend/lib/core/event.py
@@ -615,9 +615,20 @@ class EventBuilder:
         else:
             self._create_content_event(OperationType.MODIFIED, content, context)
 
+    @hookimpl
+    def on_batched_events_finished(
+        self, operation_type: OperationType, obj: object, context: TracimContext
+    ) -> None:
+        if isinstance(obj, Content):
+            self._create_content_event(operation_type, obj, context)
+        else:
+            raise NotImplementedError
+
     def _create_content_event(
         self, operation: OperationType, content: Content, context: TracimContext
     ) -> None:
+        if context.disable_events:
+            return
         current_user = context.safe_current_user()
         content_api = ContentApi(context.dbsession, current_user, self._config)
         content_in_context = content_api.get_content_in_context(content)

--- a/backend/tracim_backend/lib/utils/request.py
+++ b/backend/tracim_backend/lib/utils/request.py
@@ -76,9 +76,9 @@ class TracimContext(ABC):
             yield
         finally:
             self._disable_events = False
-            self.plugin_manager.hook.on_batched_events_finished(
-                operation_type=operation_type, obj=obj, context=self
-            )
+        self.plugin_manager.hook.on_batched_events_finished(
+            operation_type=operation_type, obj=obj, context=self
+        )
 
     @property
     def pending_events(self) -> typing.List[Event]:

--- a/backend/tracim_backend/lib/utils/request.py
+++ b/backend/tracim_backend/lib/utils/request.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from abc import ABC
 from abc import abstractmethod
+import contextlib
 from json import JSONDecodeError
 import typing
 
@@ -61,7 +62,23 @@ class TracimContext(ABC):
         self._client_token = None  # type: typing.Optional[str]
         # Pending events: have been created but are commited to the DB
         self._pending_events = []  # type: typing.List[Event]
+        self._disable_events = False
         self.force_anonymous_context = False
+
+    @property
+    def disable_events(self):
+        return self._disable_events
+
+    @contextlib.contextmanager
+    def batched_events(self, operation_type, obj: object):
+        self._disable_events = True
+        try:
+            yield
+        finally:
+            self._disable_events = False
+            self.plugin_manager.hook.on_batched_events_finished(
+                operation_type=operation_type, obj=obj, context=self
+            )
 
     @property
     def pending_events(self) -> typing.List[Event]:

--- a/backend/tracim_backend/lib/webdav/resources.py
+++ b/backend/tracim_backend/lib/webdav/resources.py
@@ -1032,6 +1032,7 @@ class FileResource(DAVNonCollection):
         try:
             self.content_api.copy(
                 item=self.content,
+                context=self.tracim_context,
                 new_label=new_label,
                 new_file_extension=new_file_extension,
                 new_parent=destination_parent,

--- a/backend/tracim_backend/migration/versions/b7aa3b477519_add_copied_and_moved_operation_type.py
+++ b/backend/tracim_backend/migration/versions/b7aa3b477519_add_copied_and_moved_operation_type.py
@@ -1,0 +1,43 @@
+"""add copied and moved operation type
+
+Revision ID: b7aa3b477519
+Revises: a0e5b5895547
+Create Date: 2022-12-16 09:55:25.274865
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "b7aa3b477519"
+down_revision = "a0e5b5895547"
+
+enum_name = "operationtype"
+old_entity_type_enum_values = (
+    "CREATED",
+    "MODIFIED",
+    "DELETED",
+    "UNDELETED",
+)
+old_entity_type_enum = sa.Enum(*old_entity_type_enum_values, name=enum_name)
+new_entity_type_enum = sa.Enum(
+    *(old_entity_type_enum_values + ("COPIED",) + ("MOVED",)), name=enum_name
+)
+
+
+def upgrade():
+    op.replace_enum(
+        table_name="events",
+        column_name="operation",
+        from_enum=old_entity_type_enum,
+        to_enum=new_entity_type_enum,
+    )
+
+
+def downgrade():
+    op.replace_enum(
+        table_name="events",
+        column_name="operation",
+        from_enum=new_entity_type_enum,
+        to_enum=old_entity_type_enum,
+    )

--- a/backend/tracim_backend/models/event.py
+++ b/backend/tracim_backend/models/event.py
@@ -30,6 +30,8 @@ class OperationType(enum.Enum):
     MODIFIED = "modified"
     DELETED = "deleted"
     UNDELETED = "undeleted"
+    COPIED = "copied"
+    MOVED = "moved"
 
     def __str__(self) -> str:
         return self.value

--- a/backend/tracim_backend/tests/library/test_content_api.py
+++ b/backend/tracim_backend/tests/library/test_content_api.py
@@ -1213,6 +1213,7 @@ class TestContentApi(object):
         user_api_factory,
         workspace_api_factory,
         session,
+        test_context,
         app_config,
         content_type_list,
         role_api_factory,
@@ -1262,7 +1263,9 @@ class TestContentApi(object):
             do_save=True,
         )
 
-        api2.copy(item=text_file, new_parent=folderb, new_label="test_file_copy")
+        api2.copy(
+            item=text_file, context=test_context, new_parent=folderb, new_label="test_file_copy"
+        )
 
         transaction.commit()
         text_file_copy = api2.get_one_by_label_and_parent("test_file_copy", folderb)
@@ -1297,6 +1300,7 @@ class TestContentApi(object):
         user_api_factory,
         workspace_api_factory,
         session,
+        test_context,
         app_config,
         content_type_list,
         role_api_factory,
@@ -1330,6 +1334,7 @@ class TestContentApi(object):
 
         api2.copy(
             item=text_file,
+            context=test_context,
             new_content_namespace=ContentNamespaces.UPLOAD,
             new_label="test_file_copy",
         )
@@ -1358,6 +1363,7 @@ class TestContentApi(object):
         user_api_factory,
         workspace_api_factory,
         session,
+        test_context,
         app_config,
         content_type_list,
         role_api_factory,
@@ -1420,7 +1426,9 @@ class TestContentApi(object):
             do_save=True,
         )
 
-        api2.copy(item=text_file, new_parent=folderb, new_label="test_file_copy")
+        api2.copy(
+            item=text_file, context=test_context, new_parent=folderb, new_label="test_file_copy"
+        )
 
         transaction.commit()
         text_file_copy = api2.get_one_by_label_and_parent("test_file_copy", folderb)
@@ -1453,6 +1461,7 @@ class TestContentApi(object):
         user_api_factory,
         workspace_api_factory,
         session,
+        test_context,
         app_config,
         content_type_list,
         role_api_factory,
@@ -1501,13 +1510,16 @@ class TestContentApi(object):
         api2.save(folderb)
 
         with pytest.raises(UnallowedSubContent):
-            api2.copy(item=text_file, new_parent=folderb, new_label="test_file_copy")
+            api2.copy(
+                item=text_file, context=test_context, new_parent=folderb, new_label="test_file_copy"
+            )
 
     def test_unit_copy_file__same_label_different_parent_ok(
         self,
         user_api_factory,
         workspace_api_factory,
         session,
+        test_context,
         app_config,
         content_type_list,
         role_api_factory,
@@ -1552,7 +1564,7 @@ class TestContentApi(object):
             label="folder b",
             do_save=True,
         )
-        api2.copy(item=text_file, new_parent=folderb)
+        api2.copy(item=text_file, context=test_context, new_parent=folderb)
 
         transaction.commit()
         text_file_copy = api2.get_one_by_label_and_parent("test_file", folderb)
@@ -1577,6 +1589,7 @@ class TestContentApi(object):
         user_api_factory,
         workspace_api_factory,
         session,
+        test_context,
         app_config,
         content_type_list,
         role_api_factory,
@@ -1613,7 +1626,7 @@ class TestContentApi(object):
         api.save(text_file, ActionDescription.CREATION)
         api2 = ContentApi(current_user=user2, session=session, config=app_config)
 
-        api2.copy(item=text_file, new_label="test_file_copy")
+        api2.copy(item=text_file, context=test_context, new_label="test_file_copy")
 
         transaction.commit()
         text_file_copy = api2.get_one_by_label_and_parent("test_file_copy", foldera)
@@ -1638,6 +1651,7 @@ class TestContentApi(object):
         user_api_factory,
         workspace_api_factory,
         session,
+        test_context,
         app_config,
         content_type_list,
         role_api_factory,
@@ -1682,13 +1696,14 @@ class TestContentApi(object):
         api2 = ContentApi(current_user=user2, session=session, config=app_config)
 
         with pytest.raises(UnallowedSubContent):
-            api2.copy(item=text_file, new_label="test_file_copy")
+            api2.copy(item=text_file, context=test_context, new_label="test_file_copy")
 
     def test_unit_copy_file_different_label_same_parent__err__label_already_used(
         self,
         user_api_factory,
         workspace_api_factory,
         session,
+        test_context,
         app_config,
         content_type_list,
         role_api_factory,
@@ -1732,7 +1747,7 @@ class TestContentApi(object):
         api.save(text_file, ActionDescription.CREATION)
         api2 = ContentApi(current_user=user2, session=session, config=app_config)
         with pytest.raises(ContentFilenameAlreadyUsedInFolder):
-            api2.copy(item=text_file, new_label="already_exist")
+            api2.copy(item=text_file, context=test_context, new_label="already_exist")
 
         transaction.commit()
         new_already_exist = api2.get_one_by_label_and_parent("already_exist", foldera)

--- a/doc/backend_specific/live_messages.md
+++ b/doc/backend_specific/live_messages.md
@@ -1,4 +1,4 @@
-## Tracim Live Messages
+# Tracim Live Messages
 
 Tracim Live Messages are events sent from the Tracim server to the browser client
 using Server-Sent-Events (SSE) on the `/api/users/<user_id>/live_messages` endpoint.
@@ -6,39 +6,42 @@ using Server-Sent-Events (SSE) on the `/api/users/<user_id>/live_messages` endpo
 The idea is that the browser client opens an HTTP connection and keep it opened to allow
 the server to keep the user informed about changes that happened in Tracim.
 
-## TLM Exemple
+## TLM Example
 
 TLM are returned as json, for example:
 
-```
+```json
 {
-    "event_id": 42,
-    "event_type": "user.created", # hierarchy in the naming: entity_type.core_event_type.optional_sub_type
-    "created": "2012-04-23T18:25:43.511Z",
-    "read_date": null,
-    "fields": { # list of fields is different depending on the event_type
-        "author": {
-            "user_id": 54,
-            "public_name": "John Doe",
-            "username": "jdoe",
-        },
-        "user": {
-            "user_id": 72,
-            "public_name": "Spam & Eggs"
-        }
+  "event_id": 42,
+  "event_type": "user.created", // hierarchy in the naming: entity_type.core_event_type.optional_sub_type
+  "created": "2012-04-23T18:25:43.511Z",
+  "read_date": null,
+  "fields": { // list of fields is different depending on the event_type
+    "author": {
+      "user_id": 54,
+      "public_name": "John Doe",
+      "username": "jdoe",
+    },
+    "user": {
+      "user_id": 72,
+      "public_name": "Spam & Eggs"
     }
+  }
 }
 ```
 
 ## TLM Types
 
 ### Core events types
+
 Possible core event types:
 
-- created (C below)
-- modified (M below)
-- deleted (D below)
-- undeleted (U below)
+- copied (__CO__ below)
+- created (__CR__ below)
+- deleted (__D__ below)
+- modified (__MD__ below)
+- moved (__MV__ below)
+- undeleted (__U__ below)
 
 ### Tracim Content types
 
@@ -54,21 +57,21 @@ content type handled in tlm are:
 There are used as sub_type for the event type "content" (see section Entities below).
 
 ### Entities
+
 Possible entity types of TLM (plus their needed fields):
 
-
-|       entity type      | core event types |    sub_types   |                 fields                 |                                            comment                                           |                                     Received by                                     |
+|       Entity type      | Core event types |    sub_types   |                 Fields                 |                                            Comment                                           |                                     Received by                                     |
 |:----------------------:|:----------------:|:-------------:|:--------------------------------------:|:--------------------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------:|
-| user                   | C/M/D/U          |               | author,user                            |   author can be null (tracimcli),   user account modification, user creation/disabling/etc  | administrators, user itself, user in at least one same space                        |
-| workspace              | C/M/D/U          |               | author,workspace                       | Space creation/deletion but also description/name update                                    | same as workspace_members if confidential, all users if not (open/on_request space) |
-| workspace_member       | C/M/D            |               | author,user,workspace,member           |  add/remove members in space but also role change                                            | administrators, user themself (if one), space members                                 |
-| content                | C/M/D/U          | any content type, e.g. "thread"  | author,workspace,content               | any content modification(create/update/deletion,etc) | space members                                                                       |
-| mention                | C                |               | author,workspace,content,mention       |  mention with "@" in note/comment                                                           | mentioned users (all space members if @all)                                         |
-| reaction               | C/D              |               | author,workspace,content,reaction,user | emoji reaction on content/comment                                                           | space members                                                                       |
-| workspace_subscription | C/M/D            |               | author, workspace, subscription, user  | subscription for on request space (with validation mecanism)                                | administrator, subscription author, workspace managers                              |
-| tag                    | C/M/D            |               | author,workspace,tag                   | tag usable in space                                                                         | same as workspace                                                                   |
-| content_tag            | C/D              |               | author,workspace,tag,content           | tag associated to a content                                                                  | space members                                                                       |
-| user_call              | C/M/D            |               | author,user_call,user                  | call feature, user is always the callee                                                                    | caller and callee users                                                             |
+| user | CR/D/MD/U |  | author,user | author can be null (tracimcli), user account modification, user creation/disabling/etc | administrators, user itself, user in at least one same space |
+| workspace | CR/D/MD/U |  | author,workspace | Space creation/deletion but also description/name update | same as workspace_members if confidential, all users if not (open/on_request space) |
+| workspace_member | CR/D/MD |  | author,user,workspace,member | add/remove members in space but also role change | administrators, user themself (if one), space members |
+| content | CO/CR/D/MD/U | any content type, e.g. "thread" | author,workspace,content | any content modification(create/update/deletion,etc) | space members |
+| mention | CR |  | author,workspace,content,mention | mention with "@" in note/comment | mentioned users (all space members if @all) |
+| reaction | CR/D |  | author,workspace,content,reaction,user | emoji reaction on content/comment | space members |
+| workspace_subscription | CR/D/MD |  | author, workspace, subscription, user  | subscription for on request space (with validation mecanism) | administrator, subscription author, workspace managers |
+| tag | CR/D/MD |  | author,workspace,tag | tag usable in space | same as workspace |
+| content_tag | CR/D |  | author,workspace,tag,content | tag associated to a content | space members |
+| user_call | CR/D/MD |  | author,user_call,user | call feature, user is always the callee | caller and callee users |
 
 ## Fields
 
@@ -78,151 +81,188 @@ Each entry in fields is a subset of the corresponding HTTP API structure.
 
 ### user and author (same as UserSchema in API)
 
-```
+```json
 {
-    "user_id": 23,
-    "username": "jdoe",
-    "public_name": "John Doe",
-    "is_active": true,
-    "is_deleted": false,
+  "user_id": 23,
+  "username": "jdoe",
+  "public_name": "John Doe",
+  "is_active": true,
+  "is_deleted": false,
 }
 ```
 
 ### workspace (same as WorkspaceSchema in API)
 
-```
+```json
 {
-    "workspace_id":  42,
-    "label": "Tracim",
-    "is_deleted": false
+  "workspace_id":  42,
+  "label": "Tracim",
+  "is_deleted": false
 }
 ```
 
 ### content/thread, content/html-document, content/folder (same as ContentSchema in API)
 
-```
+```json
 {
-    "content_id": 6,
-    "content_namespace": "",
-    "slug": "helloworld",
-    "label": "Hello world",
-    "parent_id": 5,
-    "sub_content_types": [],
-    "status": "open",
-    "is_archived": false,
-    "is_deleted": false,
-    "is_editable": true,
-    "show_in_ui": true,
-    "file_extension": ".html",
-    "filename": "helloworld.html",
-    "modified": "2012-04-23T18:28:43.511Z",
-    "created": "2012-02-23T10:28:43.511Z",
-    "actives_shares": 0,
-    "workspace_id": 23,
-    "current_revision_id": 12,
-     "current_revision_type": "edition",
-    "content_type": "html-document",
-     "raw_content": "Foobar"
+  "content_id": 6,
+  "content_namespace": "",
+  "slug": "helloworld",
+  "label": "Hello world",
+  "parent_id": 5,
+  "sub_content_types": [],
+  "status": "open",
+  "is_archived": false,
+  "is_deleted": false,
+  "is_editable": true,
+  "show_in_ui": true,
+  "file_extension": ".html",
+  "filename": "helloworld.html",
+  "modified": "2012-04-23T18:28:43.511Z",
+  "created": "2012-02-23T10:28:43.511Z",
+  "actives_shares": 0,
+  "workspace_id": 23,
+  "current_revision_id": 12,
+  "current_revision_type": "edition",
+  "content_type": "html-document",
+  "raw_content": "Foobar"
 }
 ```
 
 ### content/file, content/kanban (same as FileContentSchema in API)
 
-```
+```json
 {
-    "content_id": 6,
-    "content_namespace": "",
-    "slug": "helloworld",
-    "label": "Hello world",
-    "parent_id": 5,
-    "sub_content_types": [],
-    "status": "open",
-    "is_archived": false,
-    "is_deleted": false,
-    "is_editable": true,
-    "show_in_ui": true,
-    "file_extension": ".html",
-    "filename": "helloworld.html",
-    "modified": "2012-04-23T18:28:43.511Z",
-    "created": "2012-02-23T10:28:43.511Z",
-    "actives_shares": 0,
-    "workspace_id": 23,
-    "current_revision_id": 12,
-     "current_revision_type": "edition",
-    "content_type": "html-document",
-     "raw_content": "Hello, world",
-     "mimetype": "text/plain",
-     "size": 120,
+  "content_id": 6,
+  "content_namespace": "",
+  "slug": "helloworld",
+  "label": "Hello world",
+  "parent_id": 5,
+  "sub_content_types": [],
+  "status": "open",
+  "is_archived": false,
+  "is_deleted": false,
+  "is_editable": true,
+  "show_in_ui": true,
+  "file_extension": ".html",
+  "filename": "helloworld.html",
+  "modified": "2012-04-23T18:28:43.511Z",
+  "created": "2012-02-23T10:28:43.511Z",
+  "actives_shares": 0,
+  "workspace_id": 23,
+  "current_revision_id": 12,
+  "current_revision_type": "edition",
+  "content_type": "html-document",
+  "raw_content": "Hello, world",
+  "mimetype": "text/plain",
+  "size": 120,
 }
 ```
+
 ### content/comment (same as CommentSchema in API)
 
-```
+```json
 {
-    "content_id": 7,
-    "parent_id": 5,
-    "raw_content": "Hello",
-    "author": {
-        "avatar_url": none,
-        "user_id": 1,
-        "public_name": "John Doe"
-    },
-"created": "2012-02-23T10:28:43.511Z"
+  "content_id": 7,
+  "parent_id": 5,
+  "raw_content": "Hello",
+  "author": {
+    "avatar_url": null,
+    "user_id": 1,
+    "public_name": "John Doe"
+  },
+  "created": "2012-02-23T10:28:43.511Z"
 }
 ```
 
 ### content/todo
-```
+
+```json
 {
-    "assignee_id": "2",
-    "content_id": 7,
-    "parent_id": 5,
-    "parent_label": "New note",
-    "status": "closed-deprecated"
+  "assignee_id": "2",
+  "content_id": 7,
+  "parent_id": 5,
+  "parent_label": "New note",
+  "status": "closed-deprecated"
 }
 ```
 
 ### member
+
+```json
+{
+  "role": "reader",
+  "do_notify": false
+}
 ```
-{"role": "reader", "do_notify": false}
-```
+
 ### mention
+
+```json
+{
+  "recipient": "all"
+}
 ```
-{ "recipient": "all" }
-```
+
 ### subscription (same as WorkspaceSubscriptionSchema API)
-```
+
+```json
 {
   "state":  "pending",
   "created_date": "2020-06-15T15:05:50.955Z",  "workspace":  {
-  "workspace_id": 42, "label": "Tracim", "is_deleted": false
-},  "author": {
-"avatar_url": "/api/asset/avatars/john-doe.jpg",
-"public_name": "John Doe",
-"user_id": 3,
-"username": "My-Power_User99"
-},
-"evaluation_date": null,
-"evaluator": {
-"avatar_url": "/api/asset/avatars/john-doe.jpg",
-"public_name": "John Doe",
-"user_id": 3,
-"username": "My-Power_User99"
-}}
+    "workspace_id": 42,
+    "label": "Tracim",
+    "is_deleted": false
+  },
+  "author": {
+    "avatar_url": "/api/asset/avatars/john-doe.jpg",
+    "public_name": "John Doe",
+    "user_id": 3,
+    "username": "My-Power_User99"
+  },
+  "evaluation_date": null,
+  "evaluator": {
+    "avatar_url": "/api/asset/avatars/john-doe.jpg",
+    "public_name": "John Doe",
+    "user_id": 3,
+    "username": "My-Power_User99"
+  }
+}
 ```
 
 ### tag (same as TagSchema in API)
-```
+
+```json
 {
   "tag_name": "A tag",
   "tag_id": 23,
   "workspace_id": 12
 }
 ```
+
 ### user_call (same as UserCallSchema in API)
-```
+
+```json
 {
-"call_id": 12, "caller": { "user_id": 12, "public_name": "A user", "username": "auser", "has_avatar": true, "has_cover": false }, "callee": { "user_id": 42, "public_name": "Another user", "username": "another-user", "has_avatar": false, "has_cover": false }, "state": "in_progress", "created": "2021-08-18T12:12:02", "modified": "2021-08-18T12:12:02",
-"url": "https://meet.jit.si"
+  "call_id": 12,
+  "caller": {
+    "user_id": 12,
+    "public_name": "A user",
+    "username": "auser",
+    "has_avatar": true,
+    "has_cover": false
+  },
+  "callee": {
+    "user_id": 42,
+    "public_name": "Another user",
+    "username": "another-user",
+    "has_avatar": false,
+    "has_cover":
+    false
+  },
+  "state": "in_progress",
+  "created": "2021-08-18T12:12:02",
+  "modified": "2021-08-18T12:12:02",
+  "url": "https://meet.jit.si"
 }
 ```

--- a/frontend/src/component/FeedItem/FeedItemHeader.jsx
+++ b/frontend/src/component/FeedItem/FeedItemHeader.jsx
@@ -45,6 +45,10 @@ export class FeedItemHeader extends React.Component {
         return props.t('deleted')
       case TLM_CET.UNDELETED:
         return props.t('restored')
+      case TLM_CET.COPIED:
+        return props.t('copied')
+      case TLM_CET.MOVED:
+        return props.t('moved')
     }
     return props.t('unknown')
   }

--- a/frontend/src/container/FeedItemWithPreview.jsx
+++ b/frontend/src/container/FeedItemWithPreview.jsx
@@ -27,7 +27,6 @@ import {
   tinymceRemove,
   TLM_ENTITY_TYPE as TLM_ET,
   TLM_CORE_EVENT_TYPE as TLM_CET,
-  TLM_SUB_TYPE as TLM_ST,
   TracimComponent,
   TRANSLATION_STATE
 } from 'tracim_frontend_lib'
@@ -39,10 +38,6 @@ export class FeedItemWithPreview extends React.Component {
 
     props.registerCustomEventHandlerList([
       { name: CUSTOM_EVENT.ALL_APP_CHANGE_LANGUAGE, handler: this.handleAllAppChangeLanguage }
-    ])
-
-    props.registerLiveMessageHandlerList([
-      { entityType: TLM_ET.CONTENT, coreEntityType: TLM_CET.MODIFIED, optionalSubType: TLM_ST.COMMENT, handler: this.handleCommentModified }
     ])
 
     this.state = {
@@ -103,10 +98,6 @@ export class FeedItemWithPreview extends React.Component {
   }
 
   // TLM Handlers
-
-  handleCommentModified = (data) => {
-    this.props.updateComment(data)
-  }
 
   getWysiwygId = (contentId) => `#wysiwygTimelineComment${contentId}`
 

--- a/frontend_app_file/src/container/File.jsx
+++ b/frontend_app_file/src/container/File.jsx
@@ -137,7 +137,6 @@ export class File extends React.Component {
     ])
 
     props.registerLiveMessageHandlerList([
-      { entityType: TLM_ET.CONTENT, coreEntityType: TLM_CET.MODIFIED, optionalSubType: TLM_ST.COMMENT, handler: this.handleCommentModified },
       { entityType: TLM_ET.CONTENT, coreEntityType: TLM_CET.MODIFIED, optionalSubType: TLM_ST.FILE, handler: this.handleContentModified },
       { entityType: TLM_ET.CONTENT, coreEntityType: TLM_CET.DELETED, optionalSubType: TLM_ST.FILE, handler: this.handleContentDeletedOrRestored },
       { entityType: TLM_ET.CONTENT, coreEntityType: TLM_CET.UNDELETED, optionalSubType: TLM_ST.FILE, handler: this.handleContentDeletedOrRestored },
@@ -239,10 +238,6 @@ export class File extends React.Component {
   }
 
   // TLM Handlers
-
-  handleCommentModified = (data) => {
-    this.props.updateComment(data)
-  }
 
   handleContentModified = (data) => {
     const { state } = this

--- a/frontend_app_html-document/src/container/HtmlDocument.jsx
+++ b/frontend_app_html-document/src/container/HtmlDocument.jsx
@@ -114,7 +114,6 @@ export class HtmlDocument extends React.Component {
     ])
 
     props.registerLiveMessageHandlerList([
-      { entityType: TLM_ET.CONTENT, coreEntityType: TLM_CET.MODIFIED, optionalSubType: TLM_ST.COMMENT, handler: this.handleCommentModified },
       { entityType: TLM_ET.CONTENT, coreEntityType: TLM_CET.MODIFIED, optionalSubType: TLM_ST.HTML_DOCUMENT, handler: this.handleContentModified },
       { entityType: TLM_ET.CONTENT, coreEntityType: TLM_CET.DELETED, optionalSubType: TLM_ST.HTML_DOCUMENT, handler: this.handleContentDeleted },
       { entityType: TLM_ET.CONTENT, coreEntityType: TLM_CET.UNDELETED, optionalSubType: TLM_ST.HTML_DOCUMENT, handler: this.handleContentRestore },
@@ -126,10 +125,6 @@ export class HtmlDocument extends React.Component {
   }
 
   // TLM Handlers
-
-  handleCommentModified = (data) => {
-    this.props.updateComment(data)
-  }
 
   handleContentModified = async data => {
     const { props, state } = this

--- a/frontend_app_kanban/src/container/Kanban.jsx
+++ b/frontend_app_kanban/src/container/Kanban.jsx
@@ -94,7 +94,6 @@ export class Kanban extends React.Component {
     ])
 
     props.registerLiveMessageHandlerList([
-      { entityType: TLM_ET.CONTENT, coreEntityType: TLM_CET.MODIFIED, optionalSubType: TLM_ST.COMMENT, handler: this.handleCommentModified },
       { entityType: TLM_ET.CONTENT, coreEntityType: TLM_CET.MODIFIED, optionalSubType: TLM_ST.KANBAN, handler: this.handleContentChanged },
       { entityType: TLM_ET.CONTENT, coreEntityType: TLM_CET.DELETED, optionalSubType: TLM_ST.KANBAN, handler: this.handleContentChanged },
       { entityType: TLM_ET.CONTENT, coreEntityType: TLM_CET.UNDELETED, optionalSubType: TLM_ST.KANBAN, handler: this.handleContentChanged },
@@ -230,10 +229,6 @@ export class Kanban extends React.Component {
   }
 
   // TLM Handlers
-
-  handleCommentModified = (data) => {
-    this.props.updateComment(data)
-  }
 
   handleContentChanged = data => {
     const { state } = this

--- a/frontend_app_thread/src/container/Thread.jsx
+++ b/frontend_app_thread/src/container/Thread.jsx
@@ -84,7 +84,6 @@ export class Thread extends React.Component {
     ])
 
     props.registerLiveMessageHandlerList([
-      { entityType: TLM_ET.CONTENT, coreEntityType: TLM_CET.MODIFIED, optionalSubType: TLM_ST.COMMENT, handler: this.handleCommentModified },
       { entityType: TLM_ET.CONTENT, coreEntityType: TLM_CET.MODIFIED, optionalSubType: TLM_ST.THREAD, handler: this.handleContentChanged },
       { entityType: TLM_ET.CONTENT, coreEntityType: TLM_CET.DELETED, optionalSubType: TLM_ST.THREAD, handler: this.handleContentChanged },
       { entityType: TLM_ET.CONTENT, coreEntityType: TLM_CET.UNDELETED, optionalSubType: TLM_ST.THREAD, handler: this.handleContentChanged }
@@ -122,10 +121,6 @@ export class Thread extends React.Component {
   }
 
   // TLM Handlers
-
-  handleCommentModified = (data) => {
-    this.props.updateComment(data)
-  }
 
   handleContentChanged = data => {
     const { state } = this

--- a/frontend_lib/src/appContentFactory.js
+++ b/frontend_lib/src/appContentFactory.js
@@ -995,22 +995,6 @@ export function appContentFactory (WrappedComponent) {
       )
     }
 
-    /**
-     * Update both timeline and wholeTimeline with the new comment from the TLM
-     * @param {TLM} tlm TLM received that contains the new comment information
-     */
-    updateComment = async (tlm) => {
-      const comment = await this.getComment(tlm.fields.workspace.workspace_id, tlm.fields.content.parent_id, tlm.fields.content.content_id)
-      this.setState(prev => ({
-        timeline: prev.timeline.map(
-          item => item.content_id === comment.content_id ? { ...item, ...comment } : item
-        ),
-        wholeTimeline: prev.wholeTimeline.map(
-          item => item.content_id === comment.content_id ? { ...item, ...comment } : item
-        )
-      }))
-    }
-
     searchForMentionOrLinkInQuery = async (query, workspaceId) => {
       function matchingContentIdsFirst (contentA, contentB) {
         const aContentId = contentA.content_id.toString()
@@ -1098,7 +1082,7 @@ export function appContentFactory (WrappedComponent) {
       }
 
       const newTimeline = timeline.map(timelineItem => timelineItem.content_id === comment.content_id
-        ? { ...timelineItem, raw_content: addClassToMentionsOfUser(comment.raw_content, loggedUserUsername) }
+        ? { ...timelineItem, ...comment, raw_content: addClassToMentionsOfUser(comment.raw_content, loggedUserUsername) }
         : timelineItem
       )
       return newTimeline
@@ -1210,7 +1194,6 @@ export function appContentFactory (WrappedComponent) {
           timeline={this.state.timeline}
           loadTimeline={this.loadTimeline}
           loadMoreTimelineItems={this.loadMoreTimelineItems}
-          updateComment={this.updateComment}
           resetTimeline={this.resetTimeline}
           canLoadMoreTimelineItems={this.canLoadMoreTimelineItems}
           isLastTimelineItemCurrentToken={this.state.isLastTimelineItemCurrentToken}

--- a/frontend_lib/src/component/DropdownMenu/DropdownMenu.jsx
+++ b/frontend_lib/src/component/DropdownMenu/DropdownMenu.jsx
@@ -19,7 +19,11 @@ const DropdownMenu = props => {
         data-toggle='dropdown'
         disabled={props.buttonDisabled}
         onClick={e => { e.stopPropagation(); props.buttonClick() }}
-        title={props.buttonTooltip ? props.buttonTooltip : ((typeof props.buttonLabel) === 'string' ? props.buttonLabel : undefined)}
+        title={
+          props.buttonTooltip
+            ? props.buttonTooltip
+            : ((typeof props.buttonLabel) === 'string' ? props.buttonLabel : undefined)
+        }
         type='button'
       >
         {props.buttonOpts}

--- a/frontend_lib/src/component/TimedEvent/TimedEvent.jsx
+++ b/frontend_lib/src/component/TimedEvent/TimedEvent.jsx
@@ -26,7 +26,7 @@ const TimedEvent = (props) => {
         userId: event.author.user_id
       }}
       lang={props.lang}
-      operation={event.eventType}
+      operation={props.t(event.eventType)}
       t={props.t}
       customClass={props.customClass || ''}
       isRoot={false}

--- a/frontend_lib/src/tracimLiveMessage.js
+++ b/frontend_lib/src/tracimLiveMessage.js
@@ -17,6 +17,8 @@ const CREATED = 'created'
 const MODIFIED = 'modified'
 const DELETED = 'deleted'
 const UNDELETED = 'undeleted'
+const COPIED = 'copied'
+const MOVED = 'moved'
 
 export const TLM_SUB_TYPE = CONTENT_TYPE
 
@@ -36,5 +38,7 @@ export const TLM_CORE_EVENT_TYPE = {
   CREATED,
   MODIFIED,
   DELETED,
-  UNDELETED
+  UNDELETED,
+  COPIED,
+  MOVED
 }


### PR DESCRIPTION
Disable event creation (TLMs) during a copy and send only one event (TLM) after the copy is finished.
Reduce the amount of API calls for a modified commentary (regression during #5846)

Issue linked #6068 

## Checkpoints

<!-- These points must be checked before merging. Please don't edit them out. -->

**For developers**

- [x] If relevant, manual tests have been done to ensure the stability of the whole application and that the involved feature works
- [x] The original issue is up to date w.r.t the latest discussions and contains a short summary of the implemented solution
~~- [ ] Automated tests covering the feature or the fix, have been written, deemed irrelevant (give the reason), or an issue has been created to implement the test (give the link)~~
- [x] Make sure that:
  - if there are modifications in the Tracim configuration files (eg. `development.ini`), they are documented in `backend/doc/setting.md`
  - any migration process required for existing instances is documented
  - relevant people for these changes are notified
- [x] Original authors of the features included in a multi-feature branch (maintenance fixes -> develop, security fixes -> develop, …) should be part of the reviewers, especially if you encountered merge conflicts.

**For code reviewers**

- [x] The code is clear enough
- [x] If there are FIXMEs in the code, related issues are mentioned in the FIXME
- [x] If there are TODOs, NOTEs or HACKs in code, the date and the developer initials are present

**For testers**

- [x] Manual, quality tests have been done
