### PR TITLE
fix(frontend): links instead of js events in admin

### DIFF
--- a/frontend_app_admin_workspace_user/src/component/AdminWorkspace.jsx
+++ b/frontend_app_admin_workspace_user/src/component/AdminWorkspace.jsx
@@ -160,7 +160,7 @@ const AdminWorkspace = props => {
                     >
                       <Link
                         to={PAGE.WORKSPACE.ADVANCED_DASHBOARD(ws.workspace_id)}
-                        className='primaryColorFont primaryColorFontDarkenHover'
+                        className='adminWorkspace__workspaceTable__tr__td-link__link primaryColorFontHover'
                       >
                         {ws.label}
                       </Link>

--- a/frontend_app_admin_workspace_user/src/component/AdminWorkspace.jsx
+++ b/frontend_app_admin_workspace_user/src/component/AdminWorkspace.jsx
@@ -11,6 +11,7 @@ import {
   Loading,
   SPACE_TYPE_LIST,
   SORT_BY,
+  PAGE,
   TitleListHeader,
   EmptyListMessage,
   FilterBar,
@@ -155,9 +156,8 @@ const AdminWorkspace = props => {
                     </td>
                     <td
                       className='table__sharedSpace adminWorkspace__workspaceTable__tr__td-link primaryColorFontHover'
-                      onClick={() => props.onClickWorkspace(ws.workspace_id)}
                     >
-                      {ws.label}
+                      <a href={PAGE.WORKSPACE.ADVANCED_DASHBOARD(ws.workspace_id)}>{ws.label}</a>
                     </td>
                     <td className='table__description adminWorkspace__workspaceTable__tr__td-description'>{descriptionText}</td>
                     <td className='table__memberCount'>{ws.number_of_members}</td>

--- a/frontend_app_admin_workspace_user/src/component/AdminWorkspace.jsx
+++ b/frontend_app_admin_workspace_user/src/component/AdminWorkspace.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import { Link } from 'react-router-dom'
 import { translate } from 'react-i18next'
 import {
   Delimiter,
@@ -155,9 +156,14 @@ const AdminWorkspace = props => {
                       <div className='label'>{props.t(spaceType.label)}</div>
                     </td>
                     <td
-                      className='table__sharedSpace adminWorkspace__workspaceTable__tr__td-link primaryColorFontHover'
+                      className='table__sharedSpace adminWorkspace__workspaceTable__tr__td-link'
                     >
-                      <a href={PAGE.WORKSPACE.ADVANCED_DASHBOARD(ws.workspace_id)}>{ws.label}</a>
+                      <Link
+                        to={PAGE.WORKSPACE.ADVANCED_DASHBOARD(ws.workspace_id)}
+                        className='primaryColorFont primaryColorFontDarkenHover'
+                      >
+                        {ws.label}
+                      </Link>
                     </td>
                     <td className='table__description adminWorkspace__workspaceTable__tr__td-description'>{descriptionText}</td>
                     <td className='table__memberCount'>{ws.number_of_members}</td>

--- a/frontend_app_admin_workspace_user/src/container/AdminWorkspaceUser.jsx
+++ b/frontend_app_admin_workspace_user/src/container/AdminWorkspaceUser.jsx
@@ -575,15 +575,6 @@ export class AdminWorkspaceUser extends React.Component {
     }))
   }
 
-  handleClickSpace = workspaceId => {
-    const { state } = this
-    if (state.workspaceIdOpened === null) {
-      state.config.history.push(PAGE.WORKSPACE.ADVANCED_DASHBOARD(workspaceId), { from: 'adminSpaceList' })
-    } else GLOBAL_dispatchEvent({ type: CUSTOM_EVENT.RELOAD_CONTENT('workspace_advanced'), data: { workspace_id: workspaceId } })
-
-    this.setState({ workspaceIdOpened: workspaceId })
-  }
-
   handleClickNewSpace = () => {
     GLOBAL_dispatchEvent({ type: CUSTOM_EVENT.SHOW_CREATE_WORKSPACE_POPUP, data: {} })
   }
@@ -615,7 +606,6 @@ export class AdminWorkspaceUser extends React.Component {
           <AdminWorkspace
             loaded={state.loaded}
             workspaceList={state.displayedSpaceList}
-            onClickWorkspace={this.handleClickSpace}
             onClickNewWorkspace={this.handleClickNewSpace}
             onClickDeleteWorkspace={this.handleOpenPopupDeleteSpace}
             breadcrumbsList={state.breadcrumbsList}

--- a/frontend_app_admin_workspace_user/src/container/AdminWorkspaceUser.jsx
+++ b/frontend_app_admin_workspace_user/src/container/AdminWorkspaceUser.jsx
@@ -62,7 +62,6 @@ export class AdminWorkspaceUser extends React.Component {
       usernameInvalidMsg: '',
       popupDeleteWorkspaceDisplay: false,
       workspaceToDelete: null,
-      workspaceIdOpened: null,
       loaded: false,
       selectedSpaceSortCriteria: SORT_BY.ID,
       selectedUserSortCriteria: SORT_BY.PUBLIC_NAME,

--- a/frontend_app_admin_workspace_user/src/css/index.styl
+++ b/frontend_app_admin_workspace_user/src/css/index.styl
@@ -31,9 +31,12 @@
         white-space nowrap
         overflow hidden
         text-overflow ellipsis
-        cursor pointer
         &:not(:hover)
           color inherit
+        &__link
+          color inherit
+          margin -20px auto
+          padding 20px
       &__td-description
         max-width 0
         white-space nowrap


### PR DESCRIPTION
Issue #3953

Replace the javascript events by html links in admin spaces list

I could not run the pre-commit scripts because of requirement of https://gitlab.com/pycqa/flake8.git/ which doesn't seems to exists

## Checkpoints

<!-- These points must be checked before merging. Please don't edit them out. -->

**For developers**

- [x] If relevant, manual tests have been done to ensure the stability of the whole application and that the involved feature works
- [x] The original issue is up to date w.r.t the latest discussions and contains a short summary of the implemented solution
- [x] Automated tests covering the feature or the fix, have been written, deemed irrelevant (give the reason), or an issue has been created to implement the test (give the link) => could be added but this is a little change, and as I'm not totally sure it is the wanted behavior I'll wait for your opinion
- [x] Make sure that:
  - if there are modifications in the Tracim configuration files (eg. `development.ini`), they are documented in `backend/doc/setting.md`
  - any migration process required for existing instances is documented
  - relevant people for these changes are notified
- [x] Original authors of the features included in a multi-feature branch (maintenance fixes -> develop, security fixes -> develop, …) should be part of the reviewers, especially if you encountered merge conflicts.

**For code reviewers**

- [x] The code is clear enough
- [x] If there are FIXMEs in the code, related issues are mentioned in the FIXME
- [x] If there are TODOs, NOTEs or HACKs in code, the date and the developer initials are present

**For testers**

- [x] Manual, quality tests have been done
 - See https://github.com/tracim/tracim/pull/6149#issuecomment-1521393369 
