### PR TITLE
fix(docker): check if services running before starting tracim

### DIFF
--- a/tools_docker/Debian_New_Uwsgi/entrypoint.sh
+++ b/tools_docker/Debian_New_Uwsgi/entrypoint.sh
@@ -221,7 +221,7 @@ if [ $PUSHPIN_SERVICE_RUNNING = 0 ]; then
 fi
 ZURL_SERVICE_RUNNING=$(ps -ef | grep -v grep|grep "zurl" | wc -l)
 if [ $ZURL_SERVICE_RUNNING = 0 ]; then
-    logerror "Zurl service not start. Mandatory!!"
+    logerror "Zurl service must be running."
     exit 1
 fi
 

--- a/tools_docker/Debian_New_Uwsgi/entrypoint.sh
+++ b/tools_docker/Debian_New_Uwsgi/entrypoint.sh
@@ -211,7 +211,7 @@ fi
 ## Check running services
 REDIS_SERVICE_RUNNING=$(ps -ef | grep -v grep|grep "redis-server" | wc -l)
 if [ $REDIS_SERVICE_RUNNING = 0 ]; then
-    logerror "Redis service not start. Mandatory!!"
+    logerror "Redis service must be running."
     exit 1
 fi
 PUSHPIN_SERVICE_RUNNING=$(ps -ef | grep -v grep|grep "pushpin" | wc -l)

--- a/tools_docker/Debian_New_Uwsgi/entrypoint.sh
+++ b/tools_docker/Debian_New_Uwsgi/entrypoint.sh
@@ -207,6 +207,25 @@ if [ "$REPLY_BY_EMAIL" = "1" ];then
     log "Starting mail fetcher"
     supervisorctl start tracim_mail_fetcher
 fi
+
+## Check running services
+REDIS_SERVICE_RUNNING=$(ps -ef | grep -v grep|grep "redis-server" | wc -l)
+if [ $REDIS_SERVICE_RUNNING = 0 ]; then
+    logerror "Redis service not start. Mandatory!!"
+    exit 1
+fi
+PUSHPIN_SERVICE_RUNNING=$(ps -ef | grep -v grep|grep "pushpin" | wc -l)
+if [ $PUSHPIN_SERVICE_RUNNING = 0 ]; then
+    logerror "Pushpin service not start. Mandatory!!"
+    exit 1
+fi
+ZURL_SERVICE_RUNNING=$(ps -ef | grep -v grep|grep "zurl" | wc -l)
+if [ $ZURL_SERVICE_RUNNING = 0 ]; then
+    logerror "Zurl service not start. Mandatory!!"
+    exit 1
+fi
+
+
 # Start tracim
 log "start uwsgi"
 set +e

--- a/tools_docker/Debian_New_Uwsgi/entrypoint.sh
+++ b/tools_docker/Debian_New_Uwsgi/entrypoint.sh
@@ -216,7 +216,7 @@ if [ $REDIS_SERVICE_RUNNING = 0 ]; then
 fi
 PUSHPIN_SERVICE_RUNNING=$(ps -ef | grep -v grep|grep "pushpin" | wc -l)
 if [ $PUSHPIN_SERVICE_RUNNING = 0 ]; then
-    logerror "Pushpin service not start. Mandatory!!"
+    logerror "Pushpin service must be running."
     exit 1
 fi
 ZURL_SERVICE_RUNNING=$(ps -ef | grep -v grep|grep "zurl" | wc -l)

--- a/tools_docker/Debian_Uwsgi/entrypoint.sh
+++ b/tools_docker/Debian_Uwsgi/entrypoint.sh
@@ -211,7 +211,7 @@ if [ $PUSHPIN_SERVICE_RUNNING = 0 ]; then
 fi
 ZURL_SERVICE_RUNNING=$(ps -ef | grep -v grep|grep "zurl" | wc -l)
 if [ $ZURL_SERVICE_RUNNING = 0 ]; then
-    logerror "Zurl service not start. Mandatory!!"
+    logerror "Zurl service must be running."
     exit 1
 fi
 

--- a/tools_docker/Debian_Uwsgi/entrypoint.sh
+++ b/tools_docker/Debian_Uwsgi/entrypoint.sh
@@ -201,17 +201,17 @@ fi
 ## Check running services
 REDIS_SERVICE_RUNNING=$(ps -ef | grep -v grep|grep "redis-server" | wc -l)
 if [ $REDIS_SERVICE_RUNNING = 0 ]; then
-    logerror "Redis service not start correctly!!"
+    logerror "Redis service not start. Mandatory!!"
     exit 1
 fi
 PUSHPIN_SERVICE_RUNNING=$(ps -ef | grep -v grep|grep "pushpin" | wc -l)
 if [ $PUSHPIN_SERVICE_RUNNING = 0 ]; then
-    logerror "Pushpin service not start correctly!!"
+    logerror "Pushpin service not start. Mandatory!!"
     exit 1
 fi
 ZURL_SERVICE_RUNNING=$(ps -ef | grep -v grep|grep "zurl" | wc -l)
 if [ $ZURL_SERVICE_RUNNING = 0 ]; then
-    logerror "Zurl service not start correctly!!"
+    logerror "Zurl service not start. Mandatory!!"
     exit 1
 fi
 

--- a/tools_docker/Debian_Uwsgi/entrypoint.sh
+++ b/tools_docker/Debian_Uwsgi/entrypoint.sh
@@ -206,7 +206,7 @@ if [ $REDIS_SERVICE_RUNNING = 0 ]; then
 fi
 PUSHPIN_SERVICE_RUNNING=$(ps -ef | grep -v grep|grep "pushpin" | wc -l)
 if [ $PUSHPIN_SERVICE_RUNNING = 0 ]; then
-    logerror "Pushpin service not start. Mandatory!!"
+    logerror "Pushpin service must be running."
     exit 1
 fi
 ZURL_SERVICE_RUNNING=$(ps -ef | grep -v grep|grep "zurl" | wc -l)

--- a/tools_docker/Debian_Uwsgi/entrypoint.sh
+++ b/tools_docker/Debian_Uwsgi/entrypoint.sh
@@ -197,6 +197,25 @@ if [ "$REPLY_BY_EMAIL" = "1" ];then
     log "Starting mail fetcher"
     supervisorctl start tracim_mail_fetcher
 fi
+
+## Check running services
+REDIS_SERVICE_RUNNING=$(ps -ef | grep -v grep|grep "redis-server" | wc -l)
+if [ $REDIS_SERVICE_RUNNING = 0 ]; then
+    logerror "Redis service not start correctly!!"
+    exit 1
+fi
+PUSHPIN_SERVICE_RUNNING=$(ps -ef | grep -v grep|grep "pushpin" | wc -l)
+if [ $PUSHPIN_SERVICE_RUNNING = 0 ]; then
+    logerror "Pushpin service not start correctly!!"
+    exit 1
+fi
+ZURL_SERVICE_RUNNING=$(ps -ef | grep -v grep|grep "zurl" | wc -l)
+if [ $ZURL_SERVICE_RUNNING = 0 ]; then
+    logerror "Zurl service not start correctly!!"
+    exit 1
+fi
+
+
 # Start tracim
 log "start uwsgi"
 set +e

--- a/tools_docker/Debian_Uwsgi/entrypoint.sh
+++ b/tools_docker/Debian_Uwsgi/entrypoint.sh
@@ -201,7 +201,7 @@ fi
 ## Check running services
 REDIS_SERVICE_RUNNING=$(ps -ef | grep -v grep|grep "redis-server" | wc -l)
 if [ $REDIS_SERVICE_RUNNING = 0 ]; then
-    logerror "Redis service not start. Mandatory!!"
+    logerror "Redis service must be running."
     exit 1
 fi
 PUSHPIN_SERVICE_RUNNING=$(ps -ef | grep -v grep|grep "pushpin" | wc -l)

--- a/tools_docker/Debian_Uwsgi_ARM64/entrypoint.sh
+++ b/tools_docker/Debian_Uwsgi_ARM64/entrypoint.sh
@@ -211,7 +211,7 @@ if [ $PUSHPIN_SERVICE_RUNNING = 0 ]; then
 fi
 ZURL_SERVICE_RUNNING=$(ps -ef | grep -v grep|grep "zurl" | wc -l)
 if [ $ZURL_SERVICE_RUNNING = 0 ]; then
-    logerror "Zurl service not start. Mandatory!!"
+    logerror "Zurl service must be running."
     exit 1
 fi
 

--- a/tools_docker/Debian_Uwsgi_ARM64/entrypoint.sh
+++ b/tools_docker/Debian_Uwsgi_ARM64/entrypoint.sh
@@ -206,7 +206,7 @@ if [ $REDIS_SERVICE_RUNNING = 0 ]; then
 fi
 PUSHPIN_SERVICE_RUNNING=$(ps -ef | grep -v grep|grep "pushpin" | wc -l)
 if [ $PUSHPIN_SERVICE_RUNNING = 0 ]; then
-    logerror "Pushpin service not start. Mandatory!!"
+    logerror "Pushpin service must be running."
     exit 1
 fi
 ZURL_SERVICE_RUNNING=$(ps -ef | grep -v grep|grep "zurl" | wc -l)

--- a/tools_docker/Debian_Uwsgi_ARM64/entrypoint.sh
+++ b/tools_docker/Debian_Uwsgi_ARM64/entrypoint.sh
@@ -197,6 +197,25 @@ if [ "$REPLY_BY_EMAIL" = "1" ];then
     log "Starting mail fetcher"
     supervisorctl start tracim_mail_fetcher
 fi
+
+## Check running services
+REDIS_SERVICE_RUNNING=$(ps -ef | grep -v grep|grep "redis-server" | wc -l)
+if [ $REDIS_SERVICE_RUNNING = 0 ]; then
+    logerror "Redis service not start. Mandatory!!"
+    exit 1
+fi
+PUSHPIN_SERVICE_RUNNING=$(ps -ef | grep -v grep|grep "pushpin" | wc -l)
+if [ $PUSHPIN_SERVICE_RUNNING = 0 ]; then
+    logerror "Pushpin service not start. Mandatory!!"
+    exit 1
+fi
+ZURL_SERVICE_RUNNING=$(ps -ef | grep -v grep|grep "zurl" | wc -l)
+if [ $ZURL_SERVICE_RUNNING = 0 ]; then
+    logerror "Zurl service not start. Mandatory!!"
+    exit 1
+fi
+
+
 # Start tracim
 log "start uwsgi"
 set +e

--- a/tools_docker/Debian_Uwsgi_ARM64/entrypoint.sh
+++ b/tools_docker/Debian_Uwsgi_ARM64/entrypoint.sh
@@ -201,7 +201,7 @@ fi
 ## Check running services
 REDIS_SERVICE_RUNNING=$(ps -ef | grep -v grep|grep "redis-server" | wc -l)
 if [ $REDIS_SERVICE_RUNNING = 0 ]; then
-    logerror "Redis service not start. Mandatory!!"
+    logerror "Redis service must be running."
     exit 1
 fi
 PUSHPIN_SERVICE_RUNNING=$(ps -ef | grep -v grep|grep "pushpin" | wc -l)


### PR DESCRIPTION
Related to #6157 

This fix add verification before uwsgi start, to make sure redis-server, pushpin and zurl services works. If not, starting of tracim docker images is stopped. An error message is visible in docker logs.

Error visible for each services.
- [17:02:14] $ Redis service must be running.
- [17:10:16] $ Pushpin service must be running.
- [17:12:46] $ Zurl service must be running.

## Checkpoints

<!-- These points must be checked before merging. Please don't edit them out. -->

**For developers**

- [x] If relevant, manual tests have been done to ensure the stability of the whole application and that the involved feature works
- [x] The original issue is up to date w.r.t the latest discussions and contains a short summary of the implemented solution
- ~~Automated tests covering the feature or the fix, have been written, deemed irrelevant (give the reason), or an issue has been created to implement the test (give the link)~~
- Make sure that:
  - ~~if there are modifications in the Tracim configuration files (eg. `development.ini`), they are documented in `backend/doc/setting.md`~~
  - ~~any migration process required for existing instances is documented~~
  - ~~relevant people for these changes are notified~~
- [x] Original authors of the features included in a multi-feature branch (maintenance fixes -> develop, security fixes -> develop, …) should be part of the reviewers, especially if you encountered merge conflicts.

**For code reviewers**

- [x] The code is clear enough
- [x] If there are FIXMEs in the code, related issues are mentioned in the FIXME
- [x] If there are TODOs, NOTEs or HACKs in code, the date and the developer initials are present

**For testers**

- [ ] Manual, quality tests have been done
