### PR TITLE
fix(front): add list of handled code language highligh for app note

### DIFF
--- a/frontend/src/component/PublicProfile/CustomFormManager.jsx
+++ b/frontend/src/component/PublicProfile/CustomFormManager.jsx
@@ -233,13 +233,13 @@ const SchemaAsView = props => {
   )
 }
 
-const TextRichWidget = connect(({ user }) => ({ user }))(props => {
+const TextRichWidget = connect(({ user, system }) => ({ user, system }))(props => {
   return (
     <TinyEditor
       apiUrl=''
       setContent={(text) => { props.onChange(text) }}
       // End of required props /////////////////////////////////////////////////
-      codeLanguageList={[]}
+      codeLanguageList={props.system.config.ui__notes__code_sample_languages}
       content={props.value}
       isAdvancedEdition
       isAutoResizeEnabled={false}

--- a/frontend_app_html-document/src/container/HtmlDocument.jsx
+++ b/frontend_app_html-document/src/container/HtmlDocument.jsx
@@ -1054,6 +1054,7 @@ export class HtmlDocument extends React.Component {
             onClickRefresh={this.handleClickRefresh}
             onClickLastVersion={this.handleClickLastVersion}
             workspaceId={state.content.workspace_id}
+            codeLanguageList={state.config.system.config.ui__notes__code_sample_languages}
           />
 
           <PopinFixedRightPart


### PR DESCRIPTION
no related issue

It is to fix the code highlight language list in app note that was empty since release_04.05.00

## Checkpoints

<!-- These points must be checked before merging. Please don't edit them out. -->

**For developers**

- [x] If relevant, manual tests have been done to ensure the stability of the whole application and that the involved feature works
- [x] The original issue is up to date w.r.t the latest discussions and contains a short summary of the implemented solution
- [x] Automated tests covering the feature or the fix, have been written, deemed irrelevant (give the reason), or an issue has been created to implement the test (give the link)
- [x] Make sure that:
  - if there are modifications in the Tracim configuration files (eg. `development.ini`), they are documented in `backend/doc/setting.md`
  - any migration process required for existing instances is documented
  - relevant people for these changes are notified
- [x] Original authors of the features included in a multi-feature branch (maintenance fixes -> develop, security fixes -> develop, …) should be part of the reviewers, especially if you encountered merge conflicts.

**For code reviewers**

- [x] The code is clear enough
- [x] If there are FIXMEs in the code, related issues are mentioned in the FIXME
- [x] If there are TODOs, NOTEs or HACKs in code, the date and the developer initials are present

**For testers**

- [x] Manual, quality tests have been done
