### PR TITLE
fix: typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ We are adding to Tracim interface every translations that once reached 50%.
 
 ## Licence
 
-See [LICENCE.md](./LICENCE.md)
+Tracim is distributed under the terms of 4 distinct licenses. See [LICENSE.md](./LICENSE.md) for details
 
 ## Support
 


### PR DESCRIPTION
The link to `LICENSE.md` was still with the French spelling

Furthermore, and as a potential user, the fact that the `README` file does not give the name of the license seems strange at first sight. It is actually fully explained and clear in the `LICENSE` file that there is several licenses for _TRACIM_, and this explanation is too long for the `README`.

Thus a short explanation avoid this ambiguity.

Fixed.

## Checkpoints

<!-- These points must be checked before merging. Please don't edit them out. -->

**For developers**

- [x] If relevant, manual tests have been done to ensure the stability of the whole application and that the involved feature works
- [x] The original issue is up to date w.r.t the latest discussions and contains a short summary of the implemented solution
- [x] Automated tests covering the feature or the fix, have been written, deemed irrelevant (give the reason), or an issue has been created to implement the test (give the link)
- [x] Make sure that:
  - if there are modifications in the Tracim configuration files (eg. `development.ini`), they are documented in `backend/doc/setting.md`
  - any migration process required for existing instances is documented
  - relevant people for these changes are notified
- [x] Original authors of the features included in a multi-feature branch (maintenance fixes -> develop, security fixes -> develop, …) should be part of the reviewers, especially if you encountered merge conflicts.

**For code reviewers**

- [x] The code is clear enough
- [x] If there are FIXMEs in the code, related issues are mentioned in the FIXME
- [x] If there are TODOs, NOTEs or HACKs in code, the date and the developer initials are present

**For testers**

- [x] Manual, quality tests have been done
