### PR TITLE
fix(frontend, tinymce): re-introduce workaround for Chrome

### DIFF
--- a/frontend_lib/src/component/TinyEditor/TinyEditor.jsx
+++ b/frontend_lib/src/component/TinyEditor/TinyEditor.jsx
@@ -20,6 +20,14 @@ import {
 
 // require('./TinyEditor.styl') // see https://github.com/tracim/tracim/issues/1156
 
+const htmlCodeToDocumentFragment = (htmlCode) => {
+  // NOTE - RJ - 2021-04-28 - <template> provides a convenient content property.
+  // See https://stackoverflow.com/questions/8202195/using-document-createdocumentfragment-and-innerhtml-to-manipulate-a-dom
+  const template = document.createElement('template')
+  template.innerHTML = htmlCode
+  return template.content
+}
+
 const advancedToolBar = [
   'formatselect alignleft aligncenter alignright alignjustify | ',
   'bold italic underline strikethrough | forecolor backcolor | ',
@@ -106,6 +114,18 @@ export const TinyEditor = props => {
   const editorRef = useRef(null)
   const inputRef = useRef(null)
 
+  // HACK - SGD - 2023-06-28 - This is a workaround for
+  // https://github.com/tracim/tracim/issues/5535
+  // Since the original hack for https://github.com/tracim/tracim/issues/5622
+  // has been restored as the improved hack is not applicable with react-tiny.
+  // See also https://github.com/tracim/tracim/issues/6200
+  React.useEffect(() => {
+    if (editorRef.current) {
+      if (document.activeElement) document.activeElement.blur()
+      editorRef.current.focus()
+    }
+  }, [])
+
   const toolbar = props.isAdvancedEdition ? advancedToolBar : simpleToolBar
   // NOTE - MP - 2023-01-10 - Changing the key allow reloading the Editor component this allows us
   // to change the toolbar
@@ -151,6 +171,21 @@ export const TinyEditor = props => {
           codesample_languages: props.codeLanguageList,
           paste_data_images: true,
           relative_urls: false,
+          init_instance_callback: function (editor) {
+            // NOTE - RJ - 2021-04-28 - appending the content of the textarea
+            // after initialization instead of using TinyMCE's own mechanism works
+            // around a performance issue in Chrome with big base64 images.
+            // See https://github.com/tracim/tracim/issues/4591
+	    // And https://github.com/tracim/tracim/issues/6200
+            const body = editor.contentDocument.body
+            if (props.content !== '') {
+              body.removeAttribute('data-mce-placeholder')
+              body.removeAttribute('aria-placeholder')
+            }
+            body.textContent = ''
+            const contentFragment = htmlCodeToDocumentFragment(props.content)
+            body.appendChild(contentFragment)
+          },
           setup: (editor) => {
             editor.ui.registry.addMenuButton('insert', {
               icon: 'plus',
@@ -390,7 +425,6 @@ export const TinyEditor = props => {
             })
           }
         }}
-        value={props.content}
         onEditorChange={(newValue, editor) => props.setContent(newValue)}
         onDrop={e => base64EncodeAndTinyMceInsert(editorRef, e.dataTransfer.files)}
       />


### PR DESCRIPTION
To enable correct performance when base64 images are inserted.

Issue Ref: #4591

<!-- Here, you can write a short summary of what the pull request brings. If a related issue exists, please reference it here -->

## Checkpoints

<!-- These points must be checked before merging. Please don't edit them out. -->

**For developers**

- [x] If relevant, manual tests have been done to ensure the stability of the whole application and that the involved feature works
- [x] The original issue is up to date w.r.t the latest discussions and contains a short summary of the implemented solution
- [x] Automated tests covering the feature or the fix, have been written, deemed irrelevant (give the reason), or an issue has been created to implement the test (give the link) => Performance problem
- [x] Make sure that:
  - if there are modifications in the Tracim configuration files (eg. `development.ini`), they are documented in `backend/doc/setting.md`
  - any migration process required for existing instances is documented
  - relevant people for these changes are notified
- [x] Original authors of the features included in a multi-feature branch (maintenance fixes -> develop, security fixes -> develop, …) should be part of the reviewers, especially if you encountered merge conflicts.

**For code reviewers**

- [x] The code is clear enough
- [x] If there are FIXMEs in the code, related issues are mentioned in the FIXME
- [x] If there are TODOs, NOTEs or HACKs in code, the date and the developer initials are present

**For testers**

- [ ] Manual, quality tests have been done
