### PR TITLE
feat(front): add preview of logbook entry description and see more button

### DIFF
--- a/frontend_app_kanban/src/component/KanbanCard.jsx
+++ b/frontend_app_kanban/src/component/KanbanCard.jsx
@@ -30,9 +30,9 @@ function KanbanCard (props) {
       ? DESCRIPTION_BUTTON.SEE_MORE
       : DESCRIPTION_BUTTON.HIDDEN
     )
-  }, [])
+  }, [props.card.description])
 
-  const hancleClickSeeDescriptionButton = () => {
+  const handleClickSeeDescriptionButton = () => {
     setShowDescriptionPreview(showSeeDescriptionButton !== DESCRIPTION_BUTTON.SEE_MORE)
     setShowSeeDescriptionButton(showSeeDescriptionButton === DESCRIPTION_BUTTON.SEE_MORE
       ? DESCRIPTION_BUTTON.SEE_LESS
@@ -137,7 +137,7 @@ function KanbanCard (props) {
             dataCy='kanban_descriptionOverflow'
             intent='link'
             mode='light'
-            onClick={hancleClickSeeDescriptionButton}
+            onClick={handleClickSeeDescriptionButton}
             text={showSeeDescriptionButton === DESCRIPTION_BUTTON.SEE_MORE
               ? props.t('See more')
               : props.t('See less')}

--- a/frontend_app_logbook/src/component/LogbookEntry.jsx
+++ b/frontend_app_logbook/src/component/LogbookEntry.jsx
@@ -30,7 +30,7 @@ const LogbookEntry = (props) => {
     )
   }, [props.entry.description])
 
-  const hancleClickSeeDescriptionButton = () => {
+  const handleClickSeeDescriptionButton = () => {
     setShowDescriptionPreview(showSeeDescriptionButton !== DESCRIPTION_BUTTON.SEE_MORE)
     setShowSeeDescriptionButton(showSeeDescriptionButton === DESCRIPTION_BUTTON.SEE_MORE
       ? DESCRIPTION_BUTTON.SEE_LESS
@@ -95,7 +95,7 @@ const LogbookEntry = (props) => {
             dataCy='logbook_descriptionOverflow'
             intent='link'
             mode='light'
-            onClick={hancleClickSeeDescriptionButton}
+            onClick={handleClickSeeDescriptionButton}
             text={showSeeDescriptionButton === DESCRIPTION_BUTTON.SEE_MORE
               ? props.t('See more')
               : props.t('See less')}

--- a/frontend_app_logbook/src/component/LogbookEntry.jsx
+++ b/frontend_app_logbook/src/component/LogbookEntry.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
 import classnames from 'classnames'
 import { translate } from 'react-i18next'
@@ -9,7 +9,35 @@ import {
   shouldUseLightTextColor
 } from 'tracim_frontend_lib'
 
+require('./LogbookEntry.styl')
+
 const LogbookEntry = (props) => {
+  const DESCRIPTION_BUTTON = {
+    HIDDEN: 'hidden',
+    SEE_MORE: 'seeMore',
+    SEE_LESS: 'seeLess'
+  }
+  const [showDescriptionPreview, setShowDescriptionPreview] = useState(false)
+  const [showSeeDescriptionButton, setShowSeeDescriptionButton] = useState(DESCRIPTION_BUTTON.HIDDEN)
+
+  useEffect(() => {
+    const descriptionElement = document.getElementById(`${props.entry.id}_description`)
+    const descriptionHeight = (descriptionElement || { scrollHeight: 0 }).scrollHeight
+    setShowDescriptionPreview(descriptionHeight > 75)
+    setShowSeeDescriptionButton(descriptionHeight > 75
+      ? DESCRIPTION_BUTTON.SEE_MORE
+      : DESCRIPTION_BUTTON.HIDDEN
+    )
+  }, [props.entry.description])
+
+  const hancleClickSeeDescriptionButton = () => {
+    setShowDescriptionPreview(showSeeDescriptionButton !== DESCRIPTION_BUTTON.SEE_MORE)
+    setShowSeeDescriptionButton(showSeeDescriptionButton === DESCRIPTION_BUTTON.SEE_MORE
+      ? DESCRIPTION_BUTTON.SEE_LESS
+      : DESCRIPTION_BUTTON.SEE_MORE
+    )
+  }
+
   function formatDate () {
     try {
       return formatAbsoluteDate(new Date(props.entry.datetime), props.language, 'PPpp')
@@ -57,9 +85,25 @@ const LogbookEntry = (props) => {
           </span>
         </div>
         <div
-          className='logbook__timeline__entries__entry__data__description'
+          className={classnames('logbook__timeline__entries__entry__data__description', { logbook__timeline__entries__entry__data__description__overflow: showDescriptionPreview })}
+          id={`${props.entry.id}_description`}
           dangerouslySetInnerHTML={{ __html: props.entry.description }}
         />
+        {showSeeDescriptionButton !== DESCRIPTION_BUTTON.HIDDEN && (
+          <IconButton
+            customClass='logbook__timeline__entries__entry__data__description__overflow__button'
+            dataCy='logbook_descriptionOverflow'
+            intent='link'
+            mode='light'
+            onClick={hancleClickSeeDescriptionButton}
+            text={showSeeDescriptionButton === DESCRIPTION_BUTTON.SEE_MORE
+              ? props.t('See more')
+              : props.t('See less')}
+            textMobile={showSeeDescriptionButton === DESCRIPTION_BUTTON.SEE_MORE
+              ? props.t('See more')
+              : props.t('See less')}
+          />
+        )}
         {!props.readOnly && (
           <div className='logbook__timeline__entries__entry__data__buttons'>
             <IconButton

--- a/frontend_app_logbook/src/component/LogbookEntry.styl
+++ b/frontend_app_logbook/src/component/LogbookEntry.styl
@@ -1,0 +1,13 @@
+@import '~tracim_frontend_lib/src/css/Variable.styl'
+
+.logbook
+    &__timeline__entries__entry__data__description
+        &__overflow
+            max-height 44px
+            overflow hidden
+        &__overflow__button
+            align-self flex-start
+            font-size metadataFontSize
+            font-weight bold
+            margin-top textSpacing
+            color darkGrey1


### PR DESCRIPTION
https://github.com/tracim/tracim/issues/6522
https://github.com/tracim/tracim/issues/5270
also fix a kanban issue about the see more button not appearing on description change

## Checkpoints

<!-- These points must be checked before merging. Please don't edit them out. -->

**For developers**

- [x] If relevant, manual tests have been done to ensure the stability of the whole application and that the involved feature works
- [x] The original issue is up to date w.r.t the latest discussions and contains a short summary of the implemented solution
- [x] Automated tests covering the feature or the fix, have been written, deemed irrelevant (give the reason), or an issue has been created to implement the test (give the link)
- [x] Make sure that:
  - if there are modifications in the Tracim configuration files (eg. `development.ini`), they are documented in `backend/doc/setting.md`
  - any migration process required for existing instances is documented
  - relevant people for these changes are notified
- [x] Original authors of the features included in a multi-feature branch (maintenance fixes -> develop, security fixes -> develop, …) should be part of the reviewers, especially if you encountered merge conflicts.

**For code reviewers**

- [x] The code is clear enough
- [x] If there are FIXMEs in the code, related issues are mentioned in the FIXME
- [x] If there are TODOs, NOTEs or HACKs in code, the date and the developer initials are present

**For testers**

- [x] Manual, quality tests have been done
