### PR TITLE
fix(share): preserve label casing in RFC 5322 email addresses

### DIFF
--- a/backend/tracim_backend/applications/share/lib.py
+++ b/backend/tracim_backend/applications/share/lib.py
@@ -20,6 +20,7 @@ from tracim_backend.exceptions import NotificationSendingFailed
 from tracim_backend.exceptions import WrongSharePassword
 from tracim_backend.lib.core.content import ContentApi
 from tracim_backend.lib.mail_notifier.utils import SmtpConfiguration
+from tracim_backend.lib.mail_notifier.utils import EmailAddress
 from tracim_backend.lib.utils.logger import logger
 from tracim_backend.lib.utils.utils import core_convert_file_name_to_display
 from tracim_backend.lib.utils.utils import get_frontend_ui_base_url
@@ -63,10 +64,12 @@ class ShareLib(object):
         created = datetime.now()
         share_group_uuid = str(uuid.uuid4())
         for email in emails:
+            email_address = EmailAddress.from_rfc_email_address(email)
+            # Only lowercase the email part, preserve the label/name casing
             content_share = ContentShare(
                 author=self._user,
                 content_id=content.content_id,
-                email=email.lower(),
+                email=EmailAddress(email_address.label, email_address.email.lower()).address,
                 share_token=str(uuid.uuid4()),
                 password=password,
                 type=ContentShareType.EMAIL,

--- a/backend/tracim_backend/applications/upload_permissions/lib.py
+++ b/backend/tracim_backend/applications/upload_permissions/lib.py
@@ -28,6 +28,7 @@ from tracim_backend.exceptions import WrongSharePassword
 from tracim_backend.lib.core.content import ContentApi
 from tracim_backend.lib.core.user import UserApi
 from tracim_backend.lib.core.workspace import WorkspaceApi
+from tracim_backend.lib.mail_notifier.utils import EmailAddress
 from tracim_backend.lib.mail_notifier.utils import SmtpConfiguration
 from tracim_backend.lib.utils.logger import logger
 from tracim_backend.lib.utils.translation import Translator
@@ -75,10 +76,11 @@ class UploadPermissionLib(object):
         created = datetime.utcnow()
         upload_permission_group_uuid = str(uuid.uuid4().hex)
         for email in emails:
+            email_address = EmailAddress.from_rfc_email_address(email)
             upload_permission = UploadPermission(
                 author=self._user,
                 workspace_id=workspace.workspace_id,
-                email=email.lower(),
+                email=EmailAddress(email_address.label, email_address.email.lower()).address,
                 token=str(uuid.uuid4()),
                 password=password,
                 type=UploadPermissionType.EMAIL,


### PR DESCRIPTION
## Problem
When creating share links or upload permissions with email addresses in RFC 5322 'angle-addr' format (e.g., "John Doe <john.doe@example.com>"), the entire string was being converted to lowercase. This caused the name label to be incorrectly lowercased (e.g., "john doe <john.doe@example.com>").

See issue #6830.

## Analysis
The issue was in two locations:
- `tracim_backend/applications/share/lib.py` line 59
- `tracim_backend/applications/upload_permissions/lib.py` line 84

Both locations used `email.lower()` on the entire input string, which doesn't account for RFC 5322 angle-addr format where the name label should preserve its original casing.

The codebase already has an `EmailAddress` class in `mail_notifier/utils.py` that properly parses RFC 5322 addresses using Python's `email.utils.parseaddr()`.

## Solution
Use `EmailAddress.from_rfc_email_address()` to parse the input, then reconstruct the address with only the email part lowercased:

```python
email_address = EmailAddress.from_rfc_email_address(email)
email=EmailAddress(email_address.label, email_address.email.lower()).address
```

This preserves the label casing while ensuring the email address is normalized to lowercase.

## Testing
Verified the fix handles these cases correctly:
- `john.doe@example.com` → `john.doe@example.com` (no change)
- `John Doe <john.doe@example.com>` → `John Doe <john.doe@example.com>` (label preserved)
- `JOHN DOE <JOHN.DOE@EXAMPLE.COM>` → `JOHN DOE <john.doe@example.com>` (label preserved, email lowercased)
- `<john.doe@example.com>` → `john.doe@example.com` (brackets removed, email lowercased)
- `"John Doe" <john.doe@example.com>` → `John Doe <john.doe@example.com>` (quotes normalized)

## Notes
- The fix reuses existing `EmailAddress` infrastructure
- No database migration needed (existing data is unaffected)
- Minimal code change (5 lines modified across 2 files)