### PR TITLE
development.ini.sample: proposition to avoid mistakes with trailing commas

### DIFF
--- a/backend/development.ini.sample
+++ b/backend/development.ini.sample
@@ -99,23 +99,26 @@ basic_setup.session_secret = change_this_value_please!
 # control_uri for GRIP protocol reverse-proxy (PushPin) as a comma separated list
 # additional Pushpin instances can be provided
 # this is the base url used for publishing new events to reverse-proxy.
-; live_messages.control_zmq_uri = tcp://localhost:5563,
+# DO NOT have commas for single values.
+; live_messages.control_zmq_uri = tcp://server1:5563,tcp://server2:5563
 
 # push_uri for Pushpin as a comma separated list
 # additional Pushpin instances can be provided
 # this is used to send events to Pushpin
 # it is automatically resolved through the control_zmq_uri if Pushpin is accessible on the same
 # ports as it's configuration
+# DO NOT have commas for single values.
 ; live_messages.push_zmq_uri =
-# live_messages.push_zmq_uri = tcp://localhost:5560,
+# live_messages.push_zmq_uri = tcp://server1:5560,tcp://server2:5560
 
 # pub_uri for Pushpin as a comma separated list
 # additional Pushpin instances can be provided
 # this is used to publish events to Pushpin
 # it is automatically resolved through the control_zmq_uri if Pushpin is accessible on the same
 # ports as it's configuration
+# DO NOT have commas for single values.
 ; live_messages.pub_zmq_uri =
-# live_messages.pub_zmq_uri = tcp://localhost:5562,
+# live_messages.pub_zmq_uri = tcp://server1:5562,tcp://server2:5562
 
 # stats socket uri for GRIP protocol reverse-proxy (PushPin)
 # this is the base url used for listening to events related to connection to the
@@ -879,9 +882,10 @@ caldav.radicale.headers.Access-Control-Expose-Headers = Etag
 # elasticsearch is more effective but need an elasticsearch/opensearch server.
 ; search.engine = simple
 # elasticsearch configuration
-# to connect to a cluster, it is possible to provided multiple hosts/ports as a comma separated list
-; search.elasticsearch.host = localhost,
-; search.elasticsearch.port = 9200,
+# to connect to a cluster, for both host and port it is possible to provide multiple values as a comma separated list.
+# DO NOT have commas for single values.
+; search.elasticsearch.host = node1,node2
+; search.elasticsearch.port = 9200,9200
 # elasticsearch ssl configuration
 ; search.elasticsearch.ssl.activated = False
 ; search.elasticsearch.ssl.ca_certs =


### PR DESCRIPTION
Having trailing commas cause a crash when loading config (ValueError: invalid literal for int() with base 10: '')
