### PR TITLE
misc(frontend): use a single line to show copyright information in the footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - FilenameWithBadges React component refactoring [#6838](https://github.com/tracim/tracim/issues/6838)
 - Fix linter issues introduced in 2026.04.00
 - Fix incorrect labels [#6853](https://github.com/tracim/tracim/issues/6853)
+- Redesign the copyright footer section [#6849](https://github.com/tracim/tracim/issues/6849)
 
 
 ## 2026.04.00

--- a/frontend/src/container/Sidebar.jsx
+++ b/frontend/src/container/Sidebar.jsx
@@ -395,12 +395,8 @@ export class Sidebar extends React.Component {
 
         <div className='sidebar__footer'>
           <div className='sidebar__footer__text'>
-            {TRACIM_APP_VERSION}
-          </div>
-          <div className='sidebar__footer__text'>
-            Copyright © - 2013 - 2026
             <div className='sidebar__footer__text__link'>
-              <a href='https://www.tracim.fr' target='_blank' rel='noopener noreferrer'>tracim.fr</a>
+              <a href='https://www.tracim-teamwork.com' target='_blank' rel='noopener noreferrer'>Tracim {TRACIM_APP_VERSION}</a> ▫️ © 2013-2026
             </div>
           </div>
         </div>

--- a/frontend/src/css/Sidebar.styl
+++ b/frontend/src/css/Sidebar.styl
@@ -191,8 +191,8 @@ spacingInsideMenu = 40px
       color offWhite
       border none
   &__footer
-    margin-top auto
-    margin-bottom standardSpacing
+    margin-top (standardSpacing / 2)
+    margin-bottom (standardSpacing / 2)
     display flex
     flex-direction column
     &__text


### PR DESCRIPTION
To gain space in this section, the copyright information were moved into a single line.

The URL to the tracim project was updated from `www.tracim.fr` to `www.tracim-teamwork.com`.

The `rel` attribute cannot be removed, since the linter will raise an error when using the `target='_blank' attribute without having the rel attibute correctly set.

More information on <https://mathiasbynens.github.io/rel-noopener/>.

Related to the issue https://github.com/tracim/tracim/issues/6849.
