### PR TITLE
Fix UserConnectionStateMonitor broken due to a Python 3.11 change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### 🐛 Fixed Issues
 
 - Fix error when using "Download as PDF" action since 2026.07.00 [#6888](https://github.com/tracim/tracim/issues/6888)
-- Fix UserConnectionStateMonitor that was failing cause to `Enum.__format__()` change in Python 3.11
+- Fix UserConnectionStateMonitor that was failing cause to `Enum.__format__()` change in Python 3.11 [#6865](https://github.com/tracim/tracim/issues/6865)
 
 
 ## 2026.07.00

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### 🐛 Fixed Issues
 
 - Fix error when using "Download as PDF" action since 2026.07.00 [#6888](https://github.com/tracim/tracim/issues/6888)
+- Fix UserConnectionStateMonitor that was failing cause to `Enum.__format__()` change in Python 3.11
 
 
 ## 2026.07.00

--- a/backend/tracim_backend/lib/user_connection_state_monitor/monitor.py
+++ b/backend/tracim_backend/lib/user_connection_state_monitor/monitor.py
@@ -74,7 +74,7 @@ class UserConnectionStateMonitor:
         transaction.commit()
         logger.debug(
             self,
-            "Set connection status of user {} to {}".format(user_id or "*", status),
+            "Set connection status of user {} to {}".format(user_id or "*", status.value),
         )
 
     def add_to_pending_offline_users(self, user_id: int) -> None:


### PR DESCRIPTION
Fixes #6865 

Issue was causing TestLiveMessages.test_api__user_live_messages_endpoint_with_GRIP_proxy__err__too_many_online_users[sqlite] to fail