### PR TITLE
fix(frontend): prevent > character from appearing before mentions (Fixes #6914)

### DIFF
--- a/frontend_lib/src/mentionOrLinkOrSanitize.js
+++ b/frontend_lib/src/mentionOrLinkOrSanitize.js
@@ -99,7 +99,7 @@ export const searchMention = (text) => {
   // Regex explanation: https://regex101.com/r/hHosBa/11
   // Match (@XXX part): '@XXX', ' @XXX ', '@XXX-', ':@XXX:', '(@XXX)', '!@XXX!', ...
   // Don't match: 'XXX@XXX', '@<span>XXX</span>'
-  const mentionRegex = /(?:^|\s|\W)@([a-zA-Z0-9_.-]+)\b/g
+  const mentionRegex = /\B@([a-zA-Z0-9_.-]+)\b/g
   const mentionList = text.match(mentionRegex)
   return mentionList || []
 }
@@ -136,7 +136,7 @@ export const searchMentionAndReplaceWithTag = (userList, html) => {
       // Match (@XXX part): '@XXX', ' @XXX ', '@XXX-', ':@XXX:', '(@XXX)', '!@XXX!', ...
       // Don't match: 'XXX@XXX', '@<span>XXX</span>'
       // ${mentionText} will be replaced with role or user variable
-      const mentionRegex = new RegExp(`(?:^|\\s|\\W)@${mentionText}\\b`, 'g')
+      const mentionRegex = new RegExp(`\\B@${mentionText}\\b`, 'g')
       // NOTE - MP - 2023-04-11 - We use mention[0] because the regex lookahead is included in the
       // match
       newHtml = newHtml.replace(mentionRegex, `${mention[0]}${mentionBalise}`)


### PR DESCRIPTION
## Problem

When a note starts with a mention (e.g. `@bar`), every subsequent use of that same mention in the document gets prefixed with the `>` character.

## Root Cause

The `searchMention` function uses the regex `/(?:^|\s|\W)@([a-zA-Z0-9_.-]+)\b/g` which matches `>` (non-word character) as a valid boundary before `@`. This causes `>@bar` to be matched as a mention, and the `>` gets included in the rendered output.

## Fix

Changed the regex to `/\B@([a-zA-Z0-9_.-]+)\b/g` using `\B` (non-word boundary) instead of `(?:^|\s|\W)`. This ensures mentions are only matched at word boundaries, not after non-word characters like `>`.

Also updated the corresponding dynamic regex in `searchMentionAndReplaceWithTag`.

Fixes #6914