### PR TITLE
fix(frontend_lib): prevent > character from being captured by mention regex

### DIFF
--- a/frontend_lib/src/mentionOrLinkOrSanitize.js
+++ b/frontend_lib/src/mentionOrLinkOrSanitize.js
@@ -99,7 +99,7 @@ export const searchMention = (text) => {
   // Regex explanation: https://regex101.com/r/hHosBa/11
   // Match (@XXX part): '@XXX', ' @XXX ', '@XXX-', ':@XXX:', '(@XXX)', '!@XXX!', ...
   // Don't match: 'XXX@XXX', '@<span>XXX</span>'
-  const mentionRegex = /(?:^|\s|\W)@([a-zA-Z0-9_.-]+)\b/g
+  const mentionRegex = /(?:^|[^\w>])@([a-zA-Z0-9_.-]+)\b/g
   const mentionList = text.match(mentionRegex)
   return mentionList || []
 }
@@ -136,7 +136,7 @@ export const searchMentionAndReplaceWithTag = (userList, html) => {
       // Match (@XXX part): '@XXX', ' @XXX ', '@XXX-', ':@XXX:', '(@XXX)', '!@XXX!', ...
       // Don't match: 'XXX@XXX', '@<span>XXX</span>'
       // ${mentionText} will be replaced with role or user variable
-      const mentionRegex = new RegExp(`(?:^|\\s|\\W)@${mentionText}\\b`, 'g')
+      const mentionRegex = new RegExp(`(?:^|[^\\w>])@${mentionText}\\b`, 'g')
       // NOTE - MP - 2023-04-11 - We use mention[0] because the regex lookahead is included in the
       // match
       newHtml = newHtml.replace(mentionRegex, `${mention[0]}${mentionBalise}`)


### PR DESCRIPTION
### Issue
Fixes #6914

### Root Cause
The `searchMention` regex `/(?:^|\s|\W)@([a-zA-Z0-9_.-]+)\b/g` uses `\W` which matches `>` (greater-than) as a valid preceding character. When a note starts with a mention like `@user`, and the same mention appears later in the content, the `>` character from blockquote markup gets captured as the leading character (`mention[0]`), causing `>` to appear before the mention in the rendered output.

### Fix
Replace `\W` with `[^\w>]` in the regex to exclude `>` from the character class while keeping all other non-word characters.

Changes:
- `frontend_lib/src/mentionOrLinkOrSanitize.js`: Updated both `searchMention()` and `searchMentionAndReplaceWithTag()` regex patterns