### PR TITLE
Github issues templates : remove "related pr" section + set issue type

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,6 +2,7 @@ name: Bug report
 description: Report a bug you detected using tracim
 title: "🐛 Bug: "
 labels: ["to sort", "bug"]
+type: "Bug"
 body:
   - type: markdown
     attributes:
@@ -72,13 +73,3 @@ body:
         - Smartphone
         - Tablet
         - Other
-  - type: textarea
-    id: related-pr
-    attributes:
-      label: Related PR
-      description: |
-        Let us know if this is related to an open pull request.
-        Leave empty if there is no related PR or if you don't know.
-      placeholder: PR #0000
-    validations:
-      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,6 +2,7 @@ name: Feature request
 description: Suggest a new feature
 title: "✨ Feat: "
 labels: ["to sort", "feature"]
+type: "Feature"
 body:
   - type: markdown
     attributes:
@@ -31,13 +32,3 @@ body:
         When the user selects a content, the popup closes and the user is redirected to the content.
     validations:
       required: true
-  - type: textarea
-    id: related-pr
-    attributes:
-      label: Related PR
-      description: |
-        Let us know if this is related to an open pull request.
-        Leave empty if there is no related PR or if you don't know.
-      placeholder: PR #0000
-    validations:
-      required: false


### PR DESCRIPTION
Github can link the PR using the "development" section, and this can be done when creating the PR by adding a reference in its description ([Linking a pull request to an issue - GitHub Docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue))
As it is something we are doing every time now, I think we can get rid of the "related pr" part in the issue description ?

The "type" field ([Managing issue types in an organization - GitHub Docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/managing-issue-types-in-an-organization)) is also present, and not filed yet. This PR set the field value for Bug and Feature.