### PR TITLE
Fix Cypress error with OpenDavCal

### DIFF
--- a/concourse/pipelines/pull-request.yml
+++ b/concourse/pipelines/pull-request.yml
@@ -62,7 +62,7 @@ resources:
   type: registry-image
   source:
     repository: algooci/tracim
-    tag: build_193_node16_chromium151
+    tag: build_194_node16_chromium151
 # resource used to abort the running builds before starting our test jobs
 - name: abort-running-builds
   type: abort-running-builds

--- a/concourse/pipelines/pull-request.yml
+++ b/concourse/pipelines/pull-request.yml
@@ -62,7 +62,7 @@ resources:
   type: registry-image
   source:
     repository: algooci/tracim
-    tag: build_192_node_16
+    tag: build_193_node16_chromium151
 # resource used to abort the running builds before starting our test jobs
 - name: abort-running-builds
   type: abort-running-builds

--- a/concourse/scripts/end-to-end-cypress-tests
+++ b/concourse/scripts/end-to-end-cypress-tests
@@ -27,4 +27,5 @@ cd -
 ./setup_functionnal_tests.sh root
 ./install_frontend_dependencies.sh root
 ./build_full_frontend.sh
-NO_VIRTUAL_ENV=1 ./run_dev_backend.sh cypress run
+# HACK - PGO - 2026-08-19 - Forcing using Chromium to get rid of bundled v118 which is incompatible (#6930)
+NO_VIRTUAL_ENV=1 ./run_dev_backend.sh cypress run --browser chromium

--- a/concourse/scripts/end-to-end-cypress-tests
+++ b/concourse/scripts/end-to-end-cypress-tests
@@ -5,7 +5,7 @@ script_dir="$(realpath $(dirname $0))"
 docker_registry=${1:-""}
 
 source "$script_dir/util-lib.sh"
-skip_if_no_changed_file_match "^(frontend|backend|concourse|tools_docker/pushpin)"
+skip_if_no_changed_file_match "^(frontend|backend|concourse|tools_docker/pushpin|functionnal_tests)"
 
 "$script_dir/install_docker"
 source "$script_dir/docker-lib.sh"

--- a/concourse/scripts/install_chromium
+++ b/concourse/scripts/install_chromium
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+version="$1"
+if [ -z "$version" ]; then
+    echo "Usage: $0 <chromium-version> (e.g. 151.0.7922.137-1~deb13u1)" >&2
+    exit 1
+fi
+
+apt-get update
+apt-get install -y "chromium=${version}"
+# Prevent a later apt-get upgrade/install elsewhere in the image build from silently bumping this pin
+apt-mark hold chromium

--- a/concourse/scripts/install_chromium
+++ b/concourse/scripts/install_chromium
@@ -11,3 +11,13 @@ apt-get update
 apt-get install -y "chromium=${version}"
 # Prevent a later apt-get upgrade/install elsewhere in the image build from silently bumping this pin
 apt-mark hold chromium
+
+# HACK - PGO - 2026-08-20 - Grant clipboard read/write on the Cypress baseUrl without a permission prompt.
+# Unlike Cypress's previously bundled Electron, a real Chromium enforces the Permissions API for
+# navigator.clipboard, which has no one to click "Allow" in headless CI (#6930)
+mkdir -p /etc/chromium/policies/managed
+cat > /etc/chromium/policies/managed/tracim-cypress.json <<'EOF'
+{
+  "ClipboardAllowedForUrls": ["http://localhost:7999"]
+}
+EOF

--- a/docs.legacy/development/test/concourse.md
+++ b/docs.legacy/development/test/concourse.md
@@ -27,7 +27,7 @@ fly --target algoo login --team-name algoo --concourse-url https://ci.algoo.fr:4
 
 List all available images to look for their ids
 ```
-fly builds
+fly -t algoo builds
 ```
 
 Connect to a specific docker image by its id
@@ -39,7 +39,7 @@ fly -t algoo intercept -b build_id
 
 List the first <number_image> available image from algoo CI
 ```
-./fly builds -t algoo -c <number_image>
+./fly -t algoo builds -c <number_image>
 ```
 
 Create a file where you want to retrieve the image on local
@@ -54,16 +54,16 @@ Recuperate the image to the file created from it
 
 ### Where
 
-- <number_image>: number of image wanted, by default is 50
-- <team_name>: `algoo`
-- <build_id>: first column of `./fly builds -t algoo`
-- <step_name>: `end-to-end-cypress-tests`
-  - other available values are
-    - end-to-end-cypress-tests
-    - pull-request
-    - tracim-status-update
-- <imgae_location>: failed test in concourse will display the location after "(Screenshots)"
-- <local_file_location>: local file to put the screenshot in
+- `number_image`: number of image wanted, by default is 50
+- `team_name`: `algoo`
+- `build_id`: first column of `./fly builds -t algoo`
+- `step_name`: `end-to-end-cypress-tests`
+  - available values are:
+    - `end-to-end-cypress-tests`
+    - `pull-request`
+    - `tracim-status-update`
+- `image_location`: failed test in concourse will display the location after "(Screenshots)"
+- `local_file_location`: local file to put the screenshot in
 
 ### Example
 

--- a/docs.legacy/development/test/concourse.md
+++ b/docs.legacy/development/test/concourse.md
@@ -56,7 +56,7 @@ Recuperate the image to the file created from it
 
 - `number_image`: number of image wanted, by default is 50
 - `team_name`: `algoo`
-- `build_id`: first column of `./fly builds -t algoo`
+- `build_id`: first column of `./fly -t algoo builds`
 - `step_name`: `end-to-end-cypress-tests`
   - available values are:
     - `end-to-end-cypress-tests`

--- a/docs/contribution/code/tests_for_frontend.md
+++ b/docs/contribution/code/tests_for_frontend.md
@@ -43,7 +43,7 @@ Alternatively, under root:
 ./setup_functionnal_tests.sh root
 ```
 
-### Run interactively
+### Run all tests
 
 > [!IMPORTANT]
 > By default Cypress will use your installed Chromium version.  
@@ -54,13 +54,14 @@ Run every functional tests
 ./run_dev_backend.sh cypress run
 ```
 
-Open Cypress UI
+### Run specific tests
+
+Open Cypress UI, allowing the selection of a specific test
 ```bash
 ./run_dev_backend.sh cypress open
 ```
 
-
-### Run headlessly
+Directly launch a specific test:
 
 ```bash
 ./run_dev_backend.sh cypress run --spec "cypress/e2e/app_agenda/switching_app_agenda.cy.js"
@@ -68,6 +69,14 @@ Open Cypress UI
 
 > [!NOTE]
 > The `--spec` parameter is passed since september 2026 (#6930)
+
+> [!NOTE]
+> If run headlessly the embedded Electron browser version will be used, otherwiser installed Chromium version.
+
+> [!TIP]
+> Other available params:
+> - `--headed`: opens up a browser window
+> - `--no-exit`: keep the browser window opened
 
 
 ### Information

--- a/docs/contribution/code/tests_for_frontend.md
+++ b/docs/contribution/code/tests_for_frontend.md
@@ -68,15 +68,17 @@ Directly launch a specific test:
 ```
 
 > [!NOTE]
-> The `--spec` parameter is passed since september 2026 (#6930)
+> `run_dev_backend.sh` can pass its parameters to Cypress since september 2026 (#6930)
 
-> [!NOTE]
-> If run headlessly the embedded Electron browser version will be used, otherwiser installed Chromium version.
+> [!WARNING]
+> By default, Cypress will use its embedded Electron browser, which can be quite old.  
+> To use a locally installed browser, use the `--browser` parameter (see below)
 
 > [!TIP]
 > Other available params:
 > - `--headed`: opens up a browser window
 > - `--no-exit`: keep the browser window opened
+> - `--browser chromium`: use locally installed Chromium
 
 
 ### Information

--- a/docs/contribution/code/tests_for_frontend.md
+++ b/docs/contribution/code/tests_for_frontend.md
@@ -43,6 +43,12 @@ Alternatively, under root:
 ./setup_functionnal_tests.sh root
 ```
 
+### Run interactively
+
+> [!IMPORTANT]
+> By default Cypress will use your installed Chromium version.  
+> You can use embedded Electron Chromium version by using the Cypress home screen
+
 Run every functional tests
 ```bash
 ./run_dev_backend.sh cypress run
@@ -53,9 +59,22 @@ Open Cypress UI
 ./run_dev_backend.sh cypress open
 ```
 
-For more advanced usage, refer to the [cypress documentation](https://docs.cypress.io/).
+
+### Run headlessly
+
+```bash
+./run_dev_backend.sh cypress run --spec "cypress/e2e/app_agenda/switching_app_agenda.cy.js"
+```
+
+> [!NOTE]
+> The `--spec` parameter is passed since september 2026 (#6930)
+
 
 ### Information
+
+> [!NOTE]
+> For more advanced usage, refer to the [cypress documentation](https://docs.cypress.io/).
+
 
 Cypress tests run on their own database.
 But it doesn't use their own `depot/` folder.

--- a/functionnal_tests/cypress/plugins/index.js
+++ b/functionnal_tests/cypress/plugins/index.js
@@ -20,4 +20,17 @@ module.exports = (on, config) => {
       return null
     }
   })
+
+  // HACK - PGO - 2026-08-19
+  // The whole Concourse CI task tree (this script, Node, Cypress, and any browser it spawns)
+  // runs as root (see tools_docker/concourse/Dockerfile)
+  // A real Chromium binary (unlike Cypress's bundled Electron) refuses to start as root
+  // ("Running as root without --no-sandbox is not supported", https://crbug.com/638180),
+  // so the sandbox has to be explicitly disabled for it here.
+  on('before:browser:launch', (browser, launchOptions) => {
+    if (browser.family === 'chromium' && browser.name !== 'electron') {
+      launchOptions.args.push('--no-sandbox')
+    }
+    return launchOptions
+  })
 }

--- a/run_dev_backend.sh
+++ b/run_dev_backend.sh
@@ -10,6 +10,8 @@ $0 cypress open
     Run the Tracim backend for functional tests then launch Cypress in a GUI
 $0 cypress run
     Run the Tracim backend for functional tests then launch the full Cypress test suite in the terminal
+$0 cypress run --spec "cypress/e2e/app_agenda/switching_app_agenda.cy.js"
+    Any extra arguments after 'open'/'run' are passed through to the underlying 'cypress open'/'cypress run' command
 EOF
 }
 
@@ -41,6 +43,7 @@ backend_pid=$(pgrep pserve)
 set -e
 cypress_arg="$2"
 mode="$1"
+cypress_extra_args=("${@:3}")
 export DATABASE_NAME="tracim"
 database_dir="$script_dir/backend"
 database_service=
@@ -153,7 +156,7 @@ if [ "$mode" = "cypress" ]; then
     backend_pid=$!
     popd
     pushd "$script_dir/functionnal_tests"
-    yarn run "cypress-$cypress_arg"
+    yarn run "cypress-$cypress_arg" "${cypress_extra_args[@]}"
     teardown
 else
     # NOTE: by default the mysql/mariadb do save their database in a tmpfs.

--- a/tools_docker/concourse/Dockerfile
+++ b/tools_docker/concourse/Dockerfile
@@ -17,7 +17,13 @@ RUN \
     ./concourse/scripts/install_pyenv
 
 FROM base_install AS main
-    # tested python versions
+
+# HACK - PGO - 2026-08-19
+# Chromium version used to run Cypress, kept fixed so CI runs stay reproducible.
+#    see concourse/scripts/end-to-end-cypress-tests that forces to use Chromium intead of bundled Electron
+#    Our current Cypress 13 version has v118 that is incompatible with OpenDavCal (#6930)
+# Debian 13 is by default on Chromium 151.0.7922.137-1~deb13u1
+ARG CHROMIUM_VERSION=151.0.7922.137-1~deb13u1
 
 RUN \
     # Python versions to install in the image. \
@@ -27,5 +33,6 @@ RUN \
     ./install_frontend_dependencies.sh root && \
     # cypress \
     ./setup_functionnal_tests.sh root && \
+    ./concourse/scripts/install_chromium "$CHROMIUM_VERSION" && \
     # docker & docker compose \
     ./concourse/scripts/install_docker


### PR DESCRIPTION
Refs #6930

Only goal of this PR is to run the remaining fixes on the CI O:)

- test trigger dirs
- run_dev_backend:: allow to pass spec parameter
- documentation
- Chromium 118 VS OpenDavCal Document.parseHTMLUnsafe
