### PR TITLE
Concourse add failed test list in log tail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ functionnal_tests/cypress.json
 functionnal_tests/node_modules/
 functionnal_tests/cypress/videos
 functionnal_tests/cypress/screenshots
+functionnal_tests/cypress/failed-tests-summary.txt
 
 #ignore preview files as it is by default in backend folder
 previews

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 minversion = 2.8
 testpaths = tracim_backend
-addopts = -s -v
+addopts = -s -v -ra
 filterwarnings = ignore:.*:Warning
 env_files =
     .test.env

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 minversion = 2.8
 testpaths = tracim_backend
-addopts = -s -v -ra
+addopts = -s -v
 filterwarnings = ignore:.*:Warning
 env_files =
     .test.env

--- a/backend/tracim_backend/tests/library/test_ci_failed_list_check.py
+++ b/backend/tracim_backend/tests/library/test_ci_failed_list_check.py
@@ -1,0 +1,2 @@
+def test_deliberately_failing_to_check_ci_summary():
+    assert False, "temporary test to verify the pytest -ra failed-tests summary"

--- a/frontend_app_file/test/ci_failed_list_check.spec.js
+++ b/frontend_app_file/test/ci_failed_list_check.spec.js
@@ -1,3 +1,5 @@
+import { expect } from 'chai'
+
 describe('ci failed list check', () => {
   it('is deliberately failing to verify the mocha failed-tests summary', () => {
     expect(true).to.equal(false)

--- a/frontend_app_file/test/ci_failed_list_check.spec.js
+++ b/frontend_app_file/test/ci_failed_list_check.spec.js
@@ -1,0 +1,5 @@
+describe('ci failed list check', () => {
+  it('is deliberately failing to verify the mocha failed-tests summary', () => {
+    expect(true).to.equal(false)
+  })
+})

--- a/frontend_lib/test/ci_failed_list_check_mocha.spec.js
+++ b/frontend_lib/test/ci_failed_list_check_mocha.spec.js
@@ -1,0 +1,7 @@
+import { expect } from 'chai'
+
+describe('ci failed list check (mocha)', () => {
+  it('is deliberately failing to verify the mocha failed-tests summary', () => {
+    expect(true).to.equal(false)
+  })
+})

--- a/functionnal_tests/cypress/e2e/ci_failed_list_check.cy.js
+++ b/functionnal_tests/cypress/e2e/ci_failed_list_check.cy.js
@@ -1,0 +1,5 @@
+describe('ci failed list check', () => {
+  it('is deliberately failing to verify the after:run failed-tests summary', () => {
+    expect(true).to.equal(false)
+  })
+})

--- a/functionnal_tests/cypress/plugins/index.js
+++ b/functionnal_tests/cypress/plugins/index.js
@@ -34,12 +34,8 @@ module.exports = (on, config) => {
     return launchOptions
   })
 
-  // Cypress interleaves each spec's own failures with the rest of that
-  // spec's output, so finding every failed test in a big `cypress run` log
-  // means scrolling through all of it. `after:run` fires once, after every
-  // spec has run, with the results of the whole run -- print a single flat
-  // list of the failed tests there so it's easy to find at the end of the
-  // build log.
+  // INFO - PGO - 2026-08-21
+  // Add a summary of failed tests at the end of the log
   on('after:run', (results) => {
     if (!results || !results.totalFailed) return
 

--- a/functionnal_tests/cypress/plugins/index.js
+++ b/functionnal_tests/cypress/plugins/index.js
@@ -11,6 +11,27 @@
 // This function is called when a project is opened or re-opened (e.g. due to
 // the project's config changing)
 
+const fs = require('fs')
+const path = require('path')
+
+const FAILED_TESTS_SUMMARY_PATH = path.join(__dirname, '..', 'failed-tests-summary.txt')
+
+// No dependency on a table-formatting package just for this -- a couple of
+// padded columns is all that's needed.
+const formatFailedTestsTable = (failedTests) => {
+  const columns = ['Spec', 'Test']
+  const widths = columns.map((col) => Math.max(col.length, ...failedTests.map((row) => row[col].length)))
+  const formatRow = (cells) => '| ' + cells.map((cell, i) => cell.padEnd(widths[i])).join(' | ') + ' |'
+  const separator = '+-' + widths.map((w) => '-'.repeat(w)).join('-+-') + '-+'
+  return [
+    separator,
+    formatRow(columns),
+    separator,
+    ...failedTests.map((row) => formatRow(columns.map((col) => row[col]))),
+    separator
+  ].join('\n')
+}
+
 module.exports = (on, config) => {
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
@@ -35,18 +56,30 @@ module.exports = (on, config) => {
   })
 
   // INFO - PGO - 2026-08-21
-  // Add a summary of failed tests at the end of the log
+  // Add a summary of failed tests at the end of the log. Cypress's own
+  // per-spec results table (Spec/Tests/Passing/Failing/Pending/Skipped) has
+  // no documented way to sort, filter, or append to it, and `after:run`
+  // fires before that table is printed -- so instead of logging here (which
+  // would land *above* that table), write the summary to a file. The
+  // "cypress-run" yarn script cats it once `cypress run` has exited, which
+  // puts it after that table, at the very end of the build log.
   on('after:run', (results) => {
-    if (!results || !results.totalFailed) return
+    if (!results || !results.totalFailed) {
+      fs.rmSync(FAILED_TESTS_SUMMARY_PATH, { force: true })
+      return
+    }
 
-    console.log(`\n===== FAILED TESTS (${results.totalFailed}) =====`)
+    const failedTests = []
     for (const run of results.runs) {
       for (const test of run.tests) {
         if (test.state === 'failed') {
-          console.log(`  FAIL  ${run.spec.relative} :: ${test.title.join(' > ')}`)
+          failedTests.push({ Spec: run.spec.relative, Test: test.title.join(' > ') })
         }
       }
     }
-    console.log('=====================================\n')
+
+    const summary = `\n===== FAILED TESTS (${results.totalFailed}) =====\n` +
+      formatFailedTestsTable(failedTests) + '\n'
+    fs.writeFileSync(FAILED_TESTS_SUMMARY_PATH, summary)
   })
 }

--- a/functionnal_tests/cypress/plugins/index.js
+++ b/functionnal_tests/cypress/plugins/index.js
@@ -33,4 +33,24 @@ module.exports = (on, config) => {
     }
     return launchOptions
   })
+
+  // Cypress interleaves each spec's own failures with the rest of that
+  // spec's output, so finding every failed test in a big `cypress run` log
+  // means scrolling through all of it. `after:run` fires once, after every
+  // spec has run, with the results of the whole run -- print a single flat
+  // list of the failed tests there so it's easy to find at the end of the
+  // build log.
+  on('after:run', (results) => {
+    if (!results || !results.totalFailed) return
+
+    console.log(`\n===== FAILED TESTS (${results.totalFailed}) =====`)
+    for (const run of results.runs) {
+      for (const test of run.tests) {
+        if (test.state === 'failed') {
+          console.log(`  FAIL  ${run.spec.relative} :: ${test.title.join(' > ')}`)
+        }
+      }
+    }
+    console.log('=====================================\n')
+  })
 }

--- a/functionnal_tests/package.json
+++ b/functionnal_tests/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "echo 'Functional tests are not linted yet (see issue #3688)'",
-    "cypress-run": "cypress run",
+    "cypress-run": "cypress run \"$@\"; status=$?; cat cypress/failed-tests-summary.txt 2>/dev/null; exit $status",
     "cypress-open": "cypress open --browser chromium",
     "travis-cypress-run": "npm-scripts/travis-cypress-run"
   },

--- a/run_frontend_unit_test.sh
+++ b/run_frontend_unit_test.sh
@@ -25,11 +25,49 @@ DEFAULTDIR=$(pwd)
 export DEFAULTDIR
 echo "This is DEFAULTDIR \"$DEFAULTDIR\""
 
+# Each app's mocha output is easy to read on its own, but with ~15 apps
+# running one after another, finding which specific tests failed means
+# scrolling back through all of it. Tee every app's output to its own log so
+# a single aggregated "list of failed tests" can be printed at the very end.
+logdir=$(mktemp -d)
+failed_projects=()
+
 for project in "$DEFAULTDIR/frontend_lib" "$DEFAULTDIR/frontend" "$DEFAULTDIR"/frontend_app*; do
     if ! [ -f "$project/.disabled-app" ]; then
         cd "$project" || exit 1
-        yarn run test && loggood "success" || { logerror "Unit tests failed in $project"; STATUS=1; }
+        projectlog="$logdir/$(basename "$project").log"
+        yarn run test 2>&1 | tee "$projectlog"
+        if [ "${PIPESTATUS[0]}" -eq 0 ]; then
+            loggood "success"
+        else
+            logerror "Unit tests failed in $project"
+            STATUS=1
+            failed_projects+=("$project")
+        fi
     fi
 done
+
+if [ "${#failed_projects[@]}" -gt 0 ]; then
+    logerror "===== FAILED TESTS SUMMARY ====="
+    for project in "${failed_projects[@]}"; do
+        projectlog="$logdir/$(basename "$project").log"
+        echo -e "\n${RED}$project${NC}"
+        # Mocha prints failures as numbered blocks, e.g.:
+        #   1) Suite
+        #        test name:
+        #      AssertionError: ...
+        #       at ...
+        # Keep the numbered header/title lines plus the one-line error, drop
+        # the stack trace lines ("  at ..."). Colors are stripped first since
+        # mocha emits ANSI codes at the start of these lines even when piped.
+        sed -E 's/\x1b\[[0-9;]*m//g' "$projectlog" | awk '
+            /^  [0-9]+\)/ { inblock=1 }
+            inblock && /^ *at / { inblock=0; next }
+            inblock { print }
+        '
+    done
+fi
+
+rm -rf "$logdir"
 
 exit "$STATUS"

--- a/run_frontend_unit_test.sh
+++ b/run_frontend_unit_test.sh
@@ -64,12 +64,16 @@ if [ "${#failed_projects[@]}" -gt 0 ]; then
         #   1) Suite
         #        test name:
         #      AssertionError: ...
-        #       at ...
+        #       at Context.<anonymous> (test/some.spec.js:5:20)
+        #       at ... (internal Mocha/Node frames)
+        #
+        # The first "at" line is the test's own call site (the file we care
+        # about), the rest are internal frames -- keep the first, drop the rest.
         #
         # Warning: colors are stripped first since mocha emits ANSI codes at the start of these lines even when piped.
         sed -E 's/\x1b\[[0-9;]*m//g' "$projectlog" | awk '
             /^  [0-9]+\)/ { inblock=1 }
-            inblock && /^ *at / { inblock=0; next }
+            inblock && /^ *at / { print; inblock=0; next }
             inblock { print; next }
             /:[0-9]+:[0-9]+: / { print }
         '

--- a/run_frontend_unit_test.sh
+++ b/run_frontend_unit_test.sh
@@ -52,18 +52,26 @@ if [ "${#failed_projects[@]}" -gt 0 ]; then
     for project in "${failed_projects[@]}"; do
         projectlog="$logdir/$(basename "$project").log"
         echo -e "\n${RED}$project${NC}"
-        # Mocha prints failures as numbered blocks, e.g.:
+        # `yarn run test` consists of:
+        # - lint (standard)
+        # - mocha
+        # Either can make the build fails, and each one needs to be handled differently
+        #
+        # standard prints one "file:line:col: message" line per violation:
+        #   /path/to/file.js:3:5: 'expect' is not defined.
+        #
+        # mocha prints failures as numbered blocks, e.g.:
         #   1) Suite
         #        test name:
         #      AssertionError: ...
         #       at ...
-        # Keep the numbered header/title lines plus the one-line error, drop
-        # the stack trace lines ("  at ..."). Colors are stripped first since
-        # mocha emits ANSI codes at the start of these lines even when piped.
+        #
+        # Warning: colors are stripped first since mocha emits ANSI codes at the start of these lines even when piped.
         sed -E 's/\x1b\[[0-9;]*m//g' "$projectlog" | awk '
             /^  [0-9]+\)/ { inblock=1 }
             inblock && /^ *at / { inblock=0; next }
-            inblock { print }
+            inblock { print; next }
+            /:[0-9]+:[0-9]+: / { print }
         '
     done
 fi


### PR DESCRIPTION
Pytest is already printing a correct summary at the log end, but for the other tests suites (frontend unit test, cypress) when a test fails we have to browse the whole logs to find out its name. 

This PR aims to add a list of all failing tests at the log end.


frontend-unit-test sample:

```
[14:54:14] $ ===== FAILED TESTS SUMMARY =====

/tmp/build/77160660/pull-request/frontend_lib
  1) ci failed list check (mocha)
       is deliberately failing to verify the mocha failed-tests summary:

      AssertionError: expected true to equal false
      + expected - actual

      -true
      +false
      
      at Context.<anonymous> (test/ci_failed_list_check_mocha.spec.js:5:21)

/tmp/build/77160660/pull-request/frontend_app_file
  1) ci failed list check
       is deliberately failing to verify the mocha failed-tests summary:

      AssertionError: expected true to equal false
      + expected - actual

      -true
      +false
      
      at Context.<anonymous> (test/ci_failed_list_check.spec.js:5:21)
```

end-to-end sample:
TODO