### PR TITLE
feat(frontend): use the optimized layout for the footer copyright.

### DIFF
--- a/frontend/src/component/Login/FooterLogin.jsx
+++ b/frontend/src/component/Login/FooterLogin.jsx
@@ -5,15 +5,14 @@ require('./FooterLogin.styl')
 export const FooterLogin = () =>
   <footer className='loginpage__main__footer'>
     <div className='loginpage__main__footer__text'>
-      copyright © 2013 - 2026&nbsp;-&nbsp;
       <a
         className='loginpage__main__footer__text__link'
-        href='http://www.tracim.fr/'
+        href='https://www.tracim-teamwork.com'
         target='_blank'
         rel='noopener noreferrer'
       >
-        tracim.fr
-      </a>
+        Tracim
+      </a> ▫️ © 2013-2026
     </div>
   </footer>
 


### PR DESCRIPTION
On login and guest link pages, the copyright footer was not updated with the commit 3cbe76c02.

These pages will now have the same layout as the optimized one, without the version.

Fixes #6882.
