### PR TITLE
design: correctly align the text and the button in the PromptMessage component.

### DIFF
--- a/frontend_lib/src/component/PromptMessage/PromptMessage.styl
+++ b/frontend_lib/src/component/PromptMessage/PromptMessage.styl
@@ -10,6 +10,9 @@
   border-radius standardBorderRadius
   &.noInlineMargins
     margin-inline 0
+  &__msg, &__msg > span
+    display flex
+    align-items center
   &__msg > i
     margin-inline-end textSpacing
   &__btn


### PR DESCRIPTION

<img width="797" height="53" alt="full-prompt" src="https://github.com/user-attachments/assets/06a5c6ca-4ec3-45df-9f58-389b6480e0fe" />


Without and with this patch:
<img width="1200" height="589" alt="alignment" src="https://github.com/user-attachments/assets/15d2a40a-a7c3-4f99-9343-fe590e8ebd68" />
