### PR TITLE
fix(kanban): cannot delete a card with an unknown dependency.

### DIFF
--- a/frontend_app_kanban/src/component/KanbanCard.jsx
+++ b/frontend_app_kanban/src/component/KanbanCard.jsx
@@ -205,15 +205,17 @@ function KanbanCard (props) {
         {props.card.depends?.length > 0 && (
           <div className='kanban__contentpage__wrapper__board__card__options__depends'>
             <ul>
-              {props.card.depends.map(dependId => {
-                const dependCard = props.cardList[dependId]
-                return (
-                  <li key={dependId} title={dependCard.title}>
-                    <div style={{ backgroundColor: dependCard.bgColor }} />
-                    <span>{dependCard.title}</span>
-                  </li>
-                )
-              })}
+              {props.card.depends
+                .filter((dependId) => props.cardList[dependId])
+                .map((dependId) => {
+                  const dependCard = props.cardList[dependId]
+                  return (
+                    <li key={dependId} title={dependCard.title}>
+                      <div style={{ backgroundColor: dependCard.bgColor }} />
+                      <span>{dependCard.title}</span>
+                    </li>
+                  )
+                })}
             </ul>
           </div>
         )}


### PR DESCRIPTION
If the card have a dependency to a card which been removed, the Board will crash by trying to retrieve the information about the deleted card.
